### PR TITLE
Add Projects component with LinkedIn projects data

### DIFF
--- a/e2e/features/projects.feature
+++ b/e2e/features/projects.feature
@@ -1,0 +1,20 @@
+Feature: Projects Page
+  Verifies that the Projects page loads correctly and displays project content.
+
+  Scenario: Projects link navigates to the projects page
+    Given I go to "http://localhost:8080/"
+    When I click the Projects nav link
+    Then the URL contains "/projects"
+    And the page header is visible
+
+  Scenario: Projects page renders project section cards
+    Given I go to "http://localhost:8080/#/projects"
+    Then project section cards are visible
+
+  Scenario: Projects page contains the mySocialSecurity project
+    Given I go to "http://localhost:8080/#/projects"
+    Then the projects page contains "mySocialSecurity - Online Self Service"
+
+  Scenario: Projects page has skip link target
+    Given I go to "http://localhost:8080/#/projects"
+    Then the main content area is present

--- a/e2e/step_definitions/navigation.steps.js
+++ b/e2e/step_definitions/navigation.steps.js
@@ -12,6 +12,11 @@ When("I click the About nav link", function () {
   browser.click('button[routerlink="about"]');
 });
 
+When("I click the Projects nav link", function () {
+  browser.waitForElementVisible('button[routerlink="projects"]');
+  browser.click('button[routerlink="projects"]');
+});
+
 Then("the page header is visible", function () {
   browser.waitForElementVisible("h1");
 });
@@ -22,4 +27,16 @@ Then("the navigation menu is visible", function () {
 
 Then("the URL contains {string}", function (urlFragment) {
   browser.assert.urlContains(urlFragment);
+});
+
+Then("project section cards are visible", function () {
+  browser.waitForElementVisible(".project-section");
+});
+
+Then("the projects page contains {string}", function (text) {
+  browser.assert.textContains("body", text);
+});
+
+Then("the main content area is present", function () {
+  browser.assert.elementPresent("#maincontent");
 });

--- a/src/app/about/about-section/about-section.component.spec.ts
+++ b/src/app/about/about-section/about-section.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { AboutSectionComponent } from './about-section.component';
 
 describe('AboutSectionComponent', () => {
@@ -18,5 +17,16 @@ describe('AboutSectionComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should render the section-backpane container', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.querySelector('.section-backpane')).toBeTruthy();
+  });
+
+  it('host element should have responsive grid classes', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.classList.contains('col-12')).toBeTrue();
+    expect(el.classList.contains('col-md-5')).toBeTrue();
   });
 });

--- a/src/app/about/about.component.spec.ts
+++ b/src/app/about/about.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { AboutComponent } from './about.component';
 
 describe('AboutComponent', () => {
@@ -18,5 +17,25 @@ describe('AboutComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should have id="maincontent" as a skip link target', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.getAttribute('id')).toBe('maincontent');
+  });
+
+  it('should render multiple about sections', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const sections = el.querySelectorAll('[section]');
+    expect(sections.length).toBeGreaterThan(0);
+  });
+
+  it('section questions should be keyboard accessible', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const questions = el.querySelectorAll('h2[tabindex]');
+    expect(questions.length).toBeGreaterThan(0);
+    questions.forEach((q) => {
+      expect(q.getAttribute('tabindex')).toBe('0');
+    });
   });
 });

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -2,10 +2,12 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { HomeComponent } from './home/home.component';
 import { AboutComponent } from './about/about.component';
+import { ProjectsComponent } from './projects/projects.component';
 
 export const routes: Routes = [
   { path: 'home', component: HomeComponent },
   { path: 'about', component: AboutComponent },
+  { path: 'projects', component: ProjectsComponent },
   { path: '', redirectTo: 'home', pathMatch: 'full' },
 ];
 

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -14,13 +14,35 @@ describe('AppComponent', () => {
 
   it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app).toBeTruthy();
+    expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it(`should have as title 'usidiamond Website'`, () => {
+  it('should have the correct title', () => {
     const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual("Usi Diamond's Website");
+    expect(fixture.componentInstance.title).toEqual("Usi Diamond's Website");
+  });
+
+  it('should render a skip to main content link', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    const el: HTMLElement = fixture.nativeElement;
+    const skipLink = el.querySelector('a.skip');
+    expect(skipLink).toBeTruthy();
+    expect(skipLink!.textContent?.trim()).toBe('Skip to main content');
+  });
+
+  it('skip link should be visually hidden and focusable', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    const el: HTMLElement = fixture.nativeElement;
+    const skipLink = el.querySelector('a.skip');
+    expect(skipLink?.classList.contains('visually-hidden-focusable')).toBeTrue();
+  });
+
+  it('should render a router outlet', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.querySelector('router-outlet')).toBeTruthy();
   });
 });

--- a/src/app/footer/footer.component.spec.ts
+++ b/src/app/footer/footer.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { FooterComponent } from './footer.component';
 
 describe('FooterComponent', () => {
@@ -17,5 +16,35 @@ describe('FooterComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should render a link to the page source on GitHub', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const link = el.querySelector('a[href*="github.com/usidiamond"]');
+    expect(link).toBeTruthy();
+  });
+
+  it('GitHub source link should open in a new tab', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const link = el.querySelector('a[href*="github.com/usidiamond"]');
+    expect(link?.getAttribute('target')).toBe('_blank');
+  });
+
+  it('GitHub source link should be keyboard accessible', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const link = el.querySelector('a[href*="github.com/usidiamond"]');
+    expect(link?.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('should render a Creative Commons license link', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const link = el.querySelector('a[href*="creativecommons.org"]');
+    expect(link).toBeTruthy();
+  });
+
+  it('Creative Commons license link should open in a new tab', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const link = el.querySelector('a[href*="creativecommons.org"]');
+    expect(link?.getAttribute('target')).toBe('_blank');
   });
 });

--- a/src/app/header/header.component.spec.ts
+++ b/src/app/header/header.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { HeaderComponent } from './header.component';
 
 describe('HeaderComponent', () => {
@@ -17,5 +16,27 @@ describe('HeaderComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should render an h1 heading', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.querySelector('h1')).toBeTruthy();
+  });
+
+  it('h1 should display the site name', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const h1 = el.querySelector('h1');
+    expect(h1?.textContent).toContain("Usi'ia Lior Diamond");
+  });
+
+  it('h1 should be keyboard accessible', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const h1 = el.querySelector('h1');
+    expect(h1?.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('host element should have the personal-header id', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.getAttribute('id')).toBe('personal-header');
   });
 });

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { HomeComponent } from './home.component';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 
 describe('HomeComponent', () => {
   let component: HomeComponent;
@@ -9,6 +9,7 @@ describe('HomeComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [HomeComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
     });
     fixture = TestBed.createComponent(HomeComponent);
     component = fixture.componentInstance;
@@ -17,5 +18,27 @@ describe('HomeComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should have id="maincontent" as a skip link target', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.getAttribute('id')).toBe('maincontent');
+  });
+
+  it('should render h2 section headings', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const headings = el.querySelectorAll('h2');
+    expect(headings.length).toBeGreaterThan(0);
+  });
+
+  it('all paragraphs should have a tabindex for keyboard access', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const paragraphs = el.querySelectorAll('p[tabindex]');
+    expect(paragraphs.length).toBeGreaterThan(0);
+  });
+
+  it('should render the social links component', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.querySelector('[links-grid]')).toBeTruthy();
   });
 });

--- a/src/app/home/links/links.component.spec.ts
+++ b/src/app/home/links/links.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { LinksComponent } from './links.component';
 
 describe('LinksComponent', () => {
@@ -18,5 +17,41 @@ describe('LinksComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should render a LinkedIn link', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const link = el.querySelector('a[href*="linkedin.com/in/usidiamond"]');
+    expect(link).toBeTruthy();
+  });
+
+  it('LinkedIn link should be keyboard accessible', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const link = el.querySelector('a[href*="linkedin.com/in/usidiamond"]');
+    expect(link?.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('LinkedIn link should open in a new tab', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const link = el.querySelector('a[href*="linkedin.com/in/usidiamond"]');
+    expect(link?.getAttribute('target')).toBe('_blank');
+  });
+
+  it('should render a GitHub link', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const link = el.querySelector('a[href*="github.com/usidiamond"]');
+    expect(link).toBeTruthy();
+  });
+
+  it('GitHub link should be keyboard accessible', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const link = el.querySelector('a[href*="github.com/usidiamond"]');
+    expect(link?.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('GitHub link should open in a new tab', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const link = el.querySelector('a[href*="github.com/usidiamond"]');
+    expect(link?.getAttribute('target')).toBe('_blank');
   });
 });

--- a/src/app/menu/menu.component.html
+++ b/src/app/menu/menu.component.html
@@ -26,9 +26,8 @@
       </li>
       <li class="nav-item">
         <button
-          tabindex="-1"
-          class="nav-link disabled"
-          aria-disabled="true"
+          tabindex="0"
+          class="nav-link"
           routerLink="projects"
           routerLinkActive="active"
           ariaCurrentWhenActive="page"

--- a/src/app/menu/menu.component.spec.ts
+++ b/src/app/menu/menu.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { MenuComponent } from './menu.component';
 import { RouterModule } from '@angular/router';
 import { routes } from '../app-routing.module';
@@ -20,5 +19,50 @@ describe('MenuComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should render a nav element', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.querySelector('nav')).toBeTruthy();
+  });
+
+  it('should have an Introduction link pointing to home', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const btn = el.querySelector('button[routerLink="home"]');
+    expect(btn).toBeTruthy();
+    expect(btn?.textContent?.trim()).toBe('Introduction');
+  });
+
+  it('should have a Projects link pointing to projects', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const btn = el.querySelector('button[routerLink="projects"]');
+    expect(btn).toBeTruthy();
+    expect(btn?.textContent?.trim()).toBe('Projects');
+  });
+
+  it('should have an About link pointing to about', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const btn = el.querySelector('button[routerLink="about"]');
+    expect(btn).toBeTruthy();
+    expect(btn?.textContent?.trim()).toBe('About');
+  });
+
+  it('all nav links should be keyboard accessible', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const navBtns = el.querySelectorAll('button[routerLink]');
+    navBtns.forEach((btn) => {
+      expect(btn.getAttribute('tabindex')).not.toBe('-1');
+    });
+  });
+
+  it('no nav link should be disabled', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const disabledBtns = el.querySelectorAll('button[aria-disabled="true"]');
+    expect(disabledBtns.length).toBe(0);
+  });
+
+  it('should have a mobile navbar toggler for responsive collapse', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.querySelector('.navbar-toggler')).toBeTruthy();
   });
 });

--- a/src/app/projects/projects.component.css
+++ b/src/app/projects/projects.component.css
@@ -1,0 +1,34 @@
+h2 {
+  text-align: center;
+  color: rgb(222, 187, 255);
+}
+
+p,
+li {
+  font-family: MoreSugar;
+  font-style: italic;
+  font-weight: 700;
+}
+
+.project-date {
+  text-align: center;
+  color: rgb(181, 111, 216);
+}
+
+.project-org {
+  text-align: center;
+  color: rgb(180, 180, 180);
+}
+
+.project-section {
+  padding: 0.75em;
+  margin: 1em;
+  border-radius: 15px;
+  background: rgba(163, 163, 163);
+  background: linear-gradient(
+    90deg,
+    rgb(107, 107, 107, 1) 0%,
+    rgba(181, 111, 216, 0.2) 47%,
+    rgb(68, 114, 126, 0.5) 100%
+  );
+}

--- a/src/app/projects/projects.component.html
+++ b/src/app/projects/projects.component.html
@@ -1,0 +1,277 @@
+<div class="row justify-content-center mb-3">
+  <div class="col-12">
+    <h2 tabindex="0">What has the Usi built?</h2>
+  </div>
+</div>
+<div class="row justify-content-center">
+  <div class="col-12 col-md-10 col-lg-5 project-section">
+    <h2 tabindex="0">mySocialSecurity - Online Self Service</h2>
+    <p class="project-date" tabindex="0">Oct 2018 – Jan 2025</p>
+    <p class="project-org" tabindex="0">Social Security Administration</p>
+    <p tabindex="0">(Angular/Spring/OpenShift)</p>
+    <p tabindex="0">Worked on the following efforts and features:</p>
+    <ul tabindex="0">
+      <li>Planning, preparing, filing users Workspace.</li>
+      <li>Personalized retirement benefit estimates.</li>
+      <li>Instant estimates for spouse's benefits.</li>
+      <li>Instant proof that you do not receive benefits.</li>
+      <li>Benefit application status tracker.</li>
+      <li>On demand Social Security Statement.</li>
+      <li>Disability and survivors benefit estimates.</li>
+      <li>Replacement Social Security card.</li>
+      <li>Special Notice Request for disabled members of the public.</li>
+      <li>Current Beneficiary Workspace.</li>
+      <li>Generate an instant benefit verification letter.</li>
+      <li>Generate an instant replacement Form SSA-1099/SSA-1042.</li>
+      <li>Generate Social Security Benefit Statement.</li>
+      <li>Beneficiary direct deposit change.</li>
+      <li>Beneficiary Change your address.</li>
+      <li>
+        Allow Beneficiaries to report wages if you are working and receiving
+        disability benefits or SSI.
+      </li>
+      <li>Beneficiary Replacement Medicare card self-service.</li>
+      <li>Request a replacement Social Security card.</li>
+    </ul>
+  </div>
+
+  <div class="col-12 col-md-10 col-lg-5 project-section">
+    <h2 tabindex="0">mySocialSecurity - Representative Payee Services</h2>
+    <p class="project-date" tabindex="0">Jun 2018 – Jan 2025</p>
+    <p class="project-org" tabindex="0">Social Security Administration</p>
+    <p tabindex="0">(Angular/Spring/OpenShift)</p>
+    <p tabindex="0">
+      Implemented architecture as well as worked on the following features:
+    </p>
+    <ul tabindex="0">
+      <li>Representative Payee portal.</li>
+      <li>1099 tax forms.</li>
+      <li>Payee benefit verification letters online.</li>
+      <li>Annual Rep Payee Accounting.</li>
+      <li>Generate an instant benefit verification letter.</li>
+    </ul>
+  </div>
+
+  <div class="col-12 col-md-10 col-lg-5 project-section">
+    <h2 tabindex="0">Upload Documents</h2>
+    <p class="project-date" tabindex="0">Sep 2023 – Apr 2024</p>
+    <p class="project-org" tabindex="0">Social Security Administration</p>
+    <p tabindex="0">
+      A one stop shop for the public to be able to (through a phone, in-person,
+      or online technician request) get document requests for required SSA
+      forms, fill them out (if applicable), upload them securely, and have them
+      attached to relevant correspondences with SSA.
+    </p>
+  </div>
+
+  <div class="col-12 col-md-10 col-lg-5 project-section">
+    <h2 tabindex="0">Neurodiversity in Business Website Rewrite</h2>
+    <p class="project-date" tabindex="0">Jan 2023 – Jan 2023</p>
+    <p tabindex="0">
+      Neurodiversity in Business is a international UK based charity for
+      networking autistic and other neurodiverse persons with employers looking
+      to tap into this talent pool.
+    </p>
+  </div>
+
+  <div class="col-12 col-md-10 col-lg-5 project-section">
+    <h2 tabindex="0">mySocialSecurity - Target Cloud Architecture</h2>
+    <p class="project-date" tabindex="0">Jan 2018 – 2022</p>
+    <p class="project-org" tabindex="0">Social Security Administration</p>
+    <p tabindex="0">
+      Formulated git templates for forming Angular UI and Spring API templates
+      for testing core security, load testing, logging, library upgrade and
+      configuration changes and create documentation on how to start or migrate
+      a current project to the latest MySSA Target Architecture standard as well
+      as utilizing that template itself on critical projects with more complex
+      architectural needs.
+    </p>
+  </div>
+
+  <div class="col-12 col-md-10 col-lg-5 project-section">
+    <h2 tabindex="0">mySocialSecurity - Contact Us</h2>
+    <p class="project-date" tabindex="0">Jan 2019 – Jan 2020</p>
+    <p class="project-org" tabindex="0">Social Security Administration</p>
+    <p tabindex="0">Angular/Spring/OpenShift</p>
+  </div>
+
+  <div class="col-12 col-md-10 col-lg-5 project-section">
+    <h2 tabindex="0">Heros-Engine</h2>
+    <p class="project-date" tabindex="0">Oct 2018 – Feb 2019</p>
+    <p tabindex="0">
+      The Hero Engine aims to be an open-source HTML5 adventure game creation
+      engine based on Tiled and Phaser3.
+    </p>
+    <p tabindex="0">
+      We're calling it a meta-engine because it is not a full game engine on its
+      own, but a layer on top of Phaser3 that makes it easy to create Adventure
+      Games. The engine will provide game developers with an integration between
+      Tiled and Phaser3 that will allow for easy adventure-game-like level
+      creation. As well as common functions and UI elements that are common
+      among all adventure games.
+    </p>
+    <p tabindex="0">
+      This engine will be used to create "Command Line Heroes: The Game"
+      announced on Episode 1 of Season 2 of the Command Line Heroes Podcast.
+    </p>
+    <p tabindex="0">HTML5/WebGL/Phaser3</p>
+  </div>
+
+  <div class="col-12 col-md-10 col-lg-5 project-section">
+    <h2 tabindex="0">Enterprise Project Management Office Application</h2>
+    <p class="project-date" tabindex="0">2017 – Apr 2018</p>
+    <p class="project-org" tabindex="0">Social Security Administration</p>
+    <p tabindex="0">System for Requesting Certified Project Managers.</p>
+    <p tabindex="0">AngularJS/REST/JBossEAP/OpenShift/Oracle</p>
+  </div>
+
+  <div class="col-12 col-md-10 col-lg-5 project-section">
+    <h2 tabindex="0">Customer Engagement Tools - Customer View</h2>
+    <p class="project-date" tabindex="0">Oct 2016 – Jan 2018</p>
+    <p class="project-org" tabindex="0">Social Security Administration</p>
+    <p tabindex="0">
+      Architected a solution internally called "Skynet for customer service
+      interaction first response" — a lookup touching many legacy databases
+      wrapped in a Progressive Web App. Multiple agencies are partners in using
+      this tool.
+    </p>
+    <p tabindex="0">(Node.js/reactive.io/Spring Cloud Netflix/Apache Camel)</p>
+    <ul tabindex="0">
+      <li>
+        Modernized mainframe and web-based legacy beneficiary records viewing
+        software to a web service-oriented architecture.
+      </li>
+      <li>
+        Complete customer and family lookup across dozens of backend agency
+        services and mainframe resources.
+      </li>
+      <li>
+        Tree Navigation of Beneficiaries, their relatives, and their dependents.
+      </li>
+      <li>Special correspondence alerts for phone and in person.</li>
+      <li>
+        Alerts and filters for lookup of Individuals of Extraordinary National
+        Prominence.
+      </li>
+      <li>
+        Live UI changes in response to new data gathered based on reactive and
+        NoSQL based document building.
+      </li>
+      <li>
+        Cross Component campaigning for unified technical direction in
+        implementing a distributed on-demand customer data crawl.
+      </li>
+    </ul>
+  </div>
+
+  <div class="col-12 col-md-10 col-lg-5 project-section">
+    <h2 tabindex="0">Customer Engagement Tools - Dynamic Help</h2>
+    <p class="project-date" tabindex="0">Apr 2017 – Jan 2018</p>
+    <p class="project-org" tabindex="0">Social Security Administration</p>
+    <p tabindex="0">Chatbot and call back feature for mySSA users.</p>
+    <p tabindex="0">ZOS/Java/Parature/DB2/WebSphere</p>
+  </div>
+
+  <div class="col-12 col-md-10 col-lg-5 project-section">
+    <h2 tabindex="0">Customer Engagement Tools - Click to Chat</h2>
+    <p class="project-date" tabindex="0">2016 – Jan 2018</p>
+    <p class="project-org" tabindex="0">Social Security Administration</p>
+    <p tabindex="0">
+      Live chat application available on mySSA account page for live chat with
+      representative and management suite. (Launch Pending)
+    </p>
+    <p tabindex="0">ZOS/Java/Jabber/DB2/WebSphere</p>
+  </div>
+
+  <div class="col-12 col-md-10 col-lg-5 project-section">
+    <h2 tabindex="0">EMAC 1</h2>
+    <p class="project-date" tabindex="0">Aug 2011 – Mar 2017</p>
+    <p class="project-org" tabindex="0">Social Security Administration</p>
+    <p tabindex="0">
+      Correspondence application to manage and document requests from the
+      public, congress, and the white house.
+    </p>
+    <p tabindex="0">
+      (Waterfall/Agile) — ColdFusion/Restful/.Net/Kofax/Solaris
+    </p>
+    <p tabindex="0">*Lead Developer</p>
+  </div>
+
+  <div class="col-12 col-md-10 col-lg-5 project-section">
+    <h2 tabindex="0">LRERWMS</h2>
+    <p class="project-date" tabindex="0">Oct 2014 – Jan 2017</p>
+    <p class="project-org" tabindex="0">Social Security Administration</p>
+    <p tabindex="0">Labor Relation Employee Relation Work Management System</p>
+    <p tabindex="0">
+      Manage HR workflow for disciplinary action, legal actions, and
+      miscellaneous employee actions.
+    </p>
+    <p tabindex="0">(Waterfall) — Java/WebSphere/Solaris</p>
+  </div>
+
+  <div class="col-12 col-md-10 col-lg-5 project-section">
+    <h2 tabindex="0">AuDITS</h2>
+    <p class="project-date" tabindex="0">Oct 2015 – Jan 2016</p>
+    <p class="project-org" tabindex="0">Social Security Administration</p>
+    <p tabindex="0">
+      Manage workflow of agency audits internal and requested from OIG and other
+      agencies.
+    </p>
+    <p tabindex="0">(Agile) — Java/Websphere/Red Hat</p>
+  </div>
+
+  <div class="col-12 col-md-10 col-lg-5 project-section">
+    <h2 tabindex="0">EMAC 2</h2>
+    <p class="project-date" tabindex="0">Oct 2013 – Jan 2016</p>
+    <p class="project-org" tabindex="0">Social Security Administration</p>
+    <p tabindex="0">
+      Control application for sending top down tasks and managing rejection,
+      completion, and internal agency correspondence.
+    </p>
+    <p tabindex="0">(Waterfall) — Java/WebSphere/Solaris</p>
+    <p tabindex="0">*Lead Developer</p>
+  </div>
+
+  <div class="col-12 col-md-10 col-lg-5 project-section">
+    <h2 tabindex="0">SRDP</h2>
+    <p class="project-date" tabindex="0">Sep 2012 – Jan 2015</p>
+    <p tabindex="0">Security Request Process System</p>
+    <p tabindex="0">
+      Manage workflow and archive security requests for privileged agency
+      resources.
+    </p>
+    <p tabindex="0">(Agile) — Java/WebSphere/Solaris</p>
+    <p tabindex="0">*Lead Developer</p>
+  </div>
+
+  <div class="col-12 col-md-10 col-lg-5 project-section">
+    <h2 tabindex="0">DOORS</h2>
+    <p class="project-date" tabindex="0">Sep 2013 – Jan 2014</p>
+    <p class="project-org" tabindex="0">Social Security Administration</p>
+    <p tabindex="0">Detailed Office/Organization Resource System</p>
+    <p tabindex="0">
+      Agency directory mainframe application. COBOL-JCL backend; consulted on
+      developing Java WebSphere front-end with JS client for restful service.
+    </p>
+    <p tabindex="0">(Waterfall)</p>
+  </div>
+
+  <div class="col-12 col-md-10 col-lg-5 project-section">
+    <h2 tabindex="0">ESP</h2>
+    <p class="project-date" tabindex="0">Sep 2012 – Jan 2013</p>
+    <p tabindex="0">Employee Suggestion Program</p>
+    <p tabindex="0">Accepted and processed employee suggestions.</p>
+    <p tabindex="0">(Waterfall) — ColdFusion/IIS</p>
+  </div>
+
+  <div class="col-12 col-md-10 col-lg-5 project-section">
+    <h2 tabindex="0">Combined Federal Campaign Data Analytics and Reporting</h2>
+    <p class="project-date" tabindex="0">2011 – 2012</p>
+    <p class="project-org" tabindex="0">Social Security Administration</p>
+    <p tabindex="0">
+      Track deductions of CFC campaign contributions to registered non-profits
+      by federal employees.
+    </p>
+    <p tabindex="0">Javascript/SQLServer/ColdFusion/.NET/IIS</p>
+  </div>
+</div>

--- a/src/app/projects/projects.component.spec.ts
+++ b/src/app/projects/projects.component.spec.ts
@@ -1,0 +1,53 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ProjectsComponent } from './projects.component';
+
+describe('ProjectsComponent', () => {
+  let component: ProjectsComponent;
+  let fixture: ComponentFixture<ProjectsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ProjectsComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProjectsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should have id="maincontent" as a skip link target', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.getAttribute('id')).toBe('maincontent');
+  });
+
+  it('should render project section cards', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const sections = el.querySelectorAll('.project-section');
+    expect(sections.length).toBeGreaterThan(0);
+  });
+
+  it('all project headings should be keyboard accessible', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const headings = el.querySelectorAll('h2[tabindex]');
+    expect(headings.length).toBeGreaterThan(0);
+    headings.forEach((h) => {
+      expect(h.getAttribute('tabindex')).toBe('0');
+    });
+  });
+
+  it('all project text should have a tabindex for keyboard access', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const paragraphs = el.querySelectorAll('p[tabindex]');
+    expect(paragraphs.length).toBeGreaterThan(0);
+  });
+
+  it('should contain the mySocialSecurity Online Self Service project', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const text = el.textContent;
+    expect(text).toContain('mySocialSecurity - Online Self Service');
+  });
+});

--- a/src/app/projects/projects.component.ts
+++ b/src/app/projects/projects.component.ts
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: '[projects]',
+  host: {
+    id: 'maincontent',
+    class: 'container mt-1 mb-5',
+    style: 'background-color: rgba(255, 255, 255, 0.096); border-radius: 25px;',
+  },
+  imports: [],
+  templateUrl: './projects.component.html',
+  styleUrl: './projects.component.css',
+})
+export class ProjectsComponent {}


### PR DESCRIPTION
## Summary
- Add standalone `ProjectsComponent` displaying all 19 LinkedIn projects, styled to match the existing `home-section` pattern with Bootstrap responsive grid
- Enable the Projects nav link and register `/projects` route in app routing
- Refactor all unit test specs with meaningful accessibility and functionality assertions (skip link targets, tabindex, nav link routing, keyboard access)
- Add Cucumber integration test feature and step definitions for the Projects page

## Test plan
- [x] All 49 unit tests pass (`npm test`)
- [x] Projects nav link navigates to `/projects` route
- [x] All project sections render with correct content
- [x] Skip link targets `#maincontent` on the Projects page
- [x] Integration tests: Projects nav click, section cards visible, project text present, `#maincontent` present

🤖 Generated with [Claude Code](https://claude.com/claude-code)