### PR TITLE
Add Contact component with email link and menu nav entry

### DIFF
--- a/e2e/features/contact.feature
+++ b/e2e/features/contact.feature
@@ -1,0 +1,20 @@
+Feature: Contact Page
+  Verifies that the Contact page loads correctly and displays contact information.
+
+  Scenario: Contact link navigates to the contact page
+    Given I go to "http://localhost:8080/"
+    When I click the Contact nav link
+    Then the URL contains "/contact"
+    And the page header is visible
+
+  Scenario: Contact page has skip link target
+    Given I go to "http://localhost:8080/#/contact"
+    Then the main content area is present
+
+  Scenario: Contact page displays the email address
+    Given I go to "http://localhost:8080/#/contact"
+    Then the contact page displays "usi@usidiamond.dev"
+
+  Scenario: Contact page has a mailto link for the email address
+    Given I go to "http://localhost:8080/#/contact"
+    Then a mailto link for "usi@usidiamond.dev" is present

--- a/e2e/step_definitions/navigation.steps.js
+++ b/e2e/step_definitions/navigation.steps.js
@@ -17,6 +17,11 @@ When("I click the Projects nav link", function () {
   browser.click('button[routerlink="projects"]');
 });
 
+When("I click the Contact nav link", function () {
+  browser.waitForElementVisible('button[routerlink="contact"]');
+  browser.click('button[routerlink="contact"]');
+});
+
 Then("the page header is visible", function () {
   browser.waitForElementVisible("h1");
 });
@@ -39,4 +44,12 @@ Then("the projects page contains {string}", function (text) {
 
 Then("the main content area is present", function () {
   browser.assert.elementPresent("#maincontent");
+});
+
+Then("the contact page displays {string}", function (text) {
+  browser.assert.textContains("body", text);
+});
+
+Then("a mailto link for {string} is present", function (email) {
+  browser.assert.elementPresent(`a[href="mailto:${email}"]`);
 });

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -4,12 +4,14 @@ import { HomeComponent } from './home/home.component';
 import { AboutComponent } from './about/about.component';
 import { ProjectsComponent } from './projects/projects.component';
 import { EducationComponent } from './education/education.component';
+import { ContactComponent } from './contact/contact.component';
 
 export const routes: Routes = [
   { path: 'home', component: HomeComponent },
   { path: 'about', component: AboutComponent },
   { path: 'projects', component: ProjectsComponent },
   { path: 'education', component: EducationComponent },
+  { path: 'contact', component: ContactComponent },
   { path: '', redirectTo: 'home', pathMatch: 'full' },
 ];
 

--- a/src/app/contact/contact.component.css
+++ b/src/app/contact/contact.component.css
@@ -1,0 +1,30 @@
+h2 {
+  text-align: center;
+  color: rgb(222, 187, 255);
+}
+
+p,
+a {
+  font-family: MoreSugar;
+  font-style: italic;
+  font-weight: 700;
+}
+
+.contact-section {
+  padding: 0.75em;
+  margin: 1em;
+  border-radius: 15px;
+  background: rgba(163, 163, 163);
+  background: linear-gradient(
+    90deg,
+    rgb(107, 107, 107, 1) 0%,
+    rgba(181, 111, 216, 0.2) 47%,
+    rgb(68, 114, 126, 0.5) 100%
+  );
+}
+
+.contact-email {
+  text-align: center;
+  color: rgb(222, 187, 255);
+  font-size: 1.1em;
+}

--- a/src/app/contact/contact.component.html
+++ b/src/app/contact/contact.component.html
@@ -1,0 +1,19 @@
+<div class="row justify-content-center mb-3">
+  <div class="col-12">
+    <h2 tabindex="0">Contact</h2>
+  </div>
+</div>
+<div class="row justify-content-center">
+  <div class="col-12 col-md-10 col-lg-5 contact-section">
+    <h2 tabindex="0">Email</h2>
+    <p class="contact-email" tabindex="0">
+      <a
+        tabindex="0"
+        href="mailto:usi@usidiamond.dev"
+        style="color: rgb(222, 187, 255);"
+      >
+        usi@usidiamond.dev
+      </a>
+    </p>
+  </div>
+</div>

--- a/src/app/contact/contact.component.spec.ts
+++ b/src/app/contact/contact.component.spec.ts
@@ -1,0 +1,49 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ContactComponent } from './contact.component';
+
+describe('ContactComponent', () => {
+  let component: ContactComponent;
+  let fixture: ComponentFixture<ContactComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ContactComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ContactComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should have id="maincontent" as a skip link target', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.getAttribute('id')).toBe('maincontent');
+  });
+
+  it('should render a contact section card', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.querySelector('.contact-section')).toBeTruthy();
+  });
+
+  it('should render an email link to usi@usidiamond.dev', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const link = el.querySelector('a[href="mailto:usi@usidiamond.dev"]');
+    expect(link).toBeTruthy();
+  });
+
+  it('email link should display the human readable address', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const link = el.querySelector('a[href="mailto:usi@usidiamond.dev"]');
+    expect(link?.textContent?.trim()).toBe('usi@usidiamond.dev');
+  });
+
+  it('email link should be keyboard accessible', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const link = el.querySelector('a[href="mailto:usi@usidiamond.dev"]');
+    expect(link?.getAttribute('tabindex')).toBe('0');
+  });
+});

--- a/src/app/contact/contact.component.ts
+++ b/src/app/contact/contact.component.ts
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: '[contact]',
+  host: {
+    id: 'maincontent',
+    class: 'container mt-1 mb-5',
+    style: 'background-color: rgba(255, 255, 255, 0.096); border-radius: 25px;',
+  },
+  imports: [],
+  templateUrl: './contact.component.html',
+  styleUrl: './contact.component.css',
+})
+export class ContactComponent {}

--- a/src/app/header/header.component.css
+++ b/src/app/header/header.component.css
@@ -1,3 +1,16 @@
 h1 {
   color: rgb(222, 187, 255);
 }
+
+.contact-link a {
+  color: rgb(181, 111, 216);
+  font-family: MoreSugar;
+  font-style: italic;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.contact-link a:hover {
+  color: rgb(222, 187, 255);
+  text-decoration: underline;
+}

--- a/src/app/menu/menu.component.html
+++ b/src/app/menu/menu.component.html
@@ -57,6 +57,17 @@
           About
         </button>
       </li>
+      <li class="nav-item">
+        <button
+          tabindex="0"
+          class="nav-link"
+          routerLink="contact"
+          routerLinkActive="active"
+          ariaCurrentWhenActive="page"
+        >
+          Contact
+        </button>
+      </li>
     </ul>
   </div>
 </nav>

--- a/src/app/menu/menu.component.spec.ts
+++ b/src/app/menu/menu.component.spec.ts
@@ -54,6 +54,13 @@ describe('MenuComponent', () => {
     expect(btn?.textContent?.trim()).toBe('About');
   });
 
+  it('should have a Contact link pointing to contact', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const btn = el.querySelector('button[routerLink="contact"]');
+    expect(btn).toBeTruthy();
+    expect(btn?.textContent?.trim()).toBe('Contact');
+  });
+
   it('all nav links should be keyboard accessible', () => {
     const el: HTMLElement = fixture.nativeElement;
     const navBtns = el.querySelectorAll('button[routerLink]');


### PR DESCRIPTION
## Summary
- Add standalone `ContactComponent` with a `mailto:usi@usidiamond.dev` link displayed as the human-readable email address
- Register `/contact` route in app routing
- Add Contact nav button to the menu after About
- Add 6 unit tests covering skip link target, section card renders, mailto link present, email display text, and keyboard accessibility

## Test plan
- [x] All 71 unit tests pass (`npm test`)
- [x] Contact nav button navigates to `/contact` route
- [x] Email link displays `usi@usidiamond.dev` and opens mail client on click
- [x] Skip link targets `#maincontent` on the Contact page
- [x] Email link is keyboard accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)