### PR TITLE
Remove school section from About component

### DIFF
--- a/src/app/about/about.component.html
+++ b/src/app/about/about.component.html
@@ -65,20 +65,6 @@
     </div>
   </div>
   <div section>
-    <div question>What did Usi do in school?</div>
-    <div content>
-      <p>
-        It has a B.S. in Interdisciplinary Studies (CIS/Applied Mathematics)
-        from Stevenson University.
-      </p>
-      <p>
-        It's taken further professional/graduate level education in computer
-        Science and Mathematics at the University of Maryland Baltimore County
-        (UMBC).
-      </p>
-    </div>
-  </div>
-  <div section>
     <div question>What does the Usi do for money?</div>
     <div content>
       <p>


### PR DESCRIPTION
## Summary
- Remove the "What did Usi do in school?" section from the About component, as this information is now covered by the dedicated Education page

## Test plan
- [x] About page no longer shows the school section
- [x] Remaining About sections still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)