### PR TITLE
Post integration test summary as sticky PR comment

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -78,6 +78,14 @@ jobs:
         run: node generate-summary.js
         env:
           ARTIFACT_URL: ${{ steps.upload-report.outputs.artifact-url }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Comment integration test summary on PR
+        if: always() && github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: integration-tests
+          path: integration-tests-report/pr-comment.md
 
       - name: Publish test results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/e2e/features/volunteering.feature
+++ b/e2e/features/volunteering.feature
@@ -1,0 +1,35 @@
+Feature: Volunteering Page
+  Verifies that the Volunteering page loads and displays all volunteering content.
+
+  Scenario: Volunteering page renders volunteering section cards
+    Given I go to "http://localhost:8080/#/volunteering"
+    Then volunteering section cards are visible
+
+  Scenario: Volunteering nav link navigates to the correct page
+    Given I go to "http://localhost:8080/#/home"
+    When I click the "Volunteering" nav link
+    Then the URL contains '/volunteering'
+    And the page header is visible
+    And the navigation menu is visible
+
+  Scenario Outline: Volunteering page contains the "<entry>" entry
+    Given I go to "http://localhost:8080/#/volunteering"
+    Then the page contains "<entry>"
+
+    Examples:
+      | entry                                      |
+      | Health and Safety Specialist               |
+      | The Pride Center of Maryland               |
+      | Lead Software Development Engineer         |
+      | Neurodiversity in Business                 |
+      | Parliamentarian                            |
+      | SSA Headquarters LGBT Advisory Committee   |
+      | Chairperson                                |
+      | Securityplus Federal Credit Union          |
+      | Information Technology Risk Manager        |
+      | Life Care Services                         |
+      | The Audrey Herman Spotlighters Theatre     |
+      | Greenspring Valley Orchestra               |
+      | Young Victorian Theatre Company            |
+      | Baltimore Playwrights Festival             |
+      | Opera Vivente                              |

--- a/e2e/step_definitions/navigation.steps.js
+++ b/e2e/step_definitions/navigation.steps.js
@@ -6,6 +6,7 @@ const navLabelToRoute = {
   Introduction: "home",
   Projects: "projects",
   Education: "education",
+  Volunteering: "volunteering",
   About: "about",
   Contact: "contact",
 };
@@ -42,6 +43,10 @@ Then("project section cards are visible", function () {
 
 Then("education section cards are visible", function () {
   browser.waitForElementVisible(".education-section");
+});
+
+Then("volunteering section cards are visible", function () {
+  browser.waitForElementVisible(".volunteering-section");
 });
 
 Then("a link to {string} is present", function (urlFragment) {

--- a/generate-summary.js
+++ b/generate-summary.js
@@ -14,7 +14,9 @@ const path = require("path");
 
 const REPORT_PATH = "integration-tests-report/cucumber-report.json";
 const SUMMARY_FILE = process.env.GITHUB_STEP_SUMMARY;
+const PR_COMMENT_FILE = "integration-tests-report/pr-comment.md";
 const ARTIFACT_URL = process.env.ARTIFACT_URL || "";
+const RUN_URL = process.env.RUN_URL || "";
 
 if (!fs.existsSync(REPORT_PATH)) {
   console.log("No cucumber report found at", REPORT_PATH);
@@ -104,6 +106,10 @@ if (ARTIFACT_URL) {
   );
 }
 
+if (RUN_URL) {
+  lines.push(`\n[View full workflow run ↗](${RUN_URL})`);
+}
+
 const summary = lines.join("\n");
 
 if (SUMMARY_FILE) {
@@ -112,4 +118,13 @@ if (SUMMARY_FILE) {
 } else {
   console.log("GITHUB_STEP_SUMMARY not set — preview:");
   console.log(summary);
+}
+
+// Always write a file copy so the workflow can post it as a PR comment.
+try {
+  fs.mkdirSync(path.dirname(PR_COMMENT_FILE), { recursive: true });
+  fs.writeFileSync(PR_COMMENT_FILE, summary + "\n");
+  console.log(`PR comment body written to ${PR_COMMENT_FILE}`);
+} catch (e) {
+  console.error("Failed to write PR comment file:", e.message);
 }

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -5,12 +5,14 @@ import { AboutComponent } from './about/about.component';
 import { ProjectsComponent } from './projects/projects.component';
 import { EducationComponent } from './education/education.component';
 import { ContactComponent } from './contact/contact.component';
+import { VolunteeringComponent } from './volunteering/volunteering.component';
 
 export const routes: Routes = [
   { path: 'home', component: HomeComponent },
   { path: 'about', component: AboutComponent },
   { path: 'projects', component: ProjectsComponent },
   { path: 'education', component: EducationComponent },
+  { path: 'volunteering', component: VolunteeringComponent },
   { path: 'contact', component: ContactComponent },
   { path: '', redirectTo: 'home', pathMatch: 'full' },
 ];

--- a/src/app/menu/menu.component.html
+++ b/src/app/menu/menu.component.html
@@ -50,6 +50,17 @@
         <button
           tabindex="0"
           class="nav-link"
+          routerLink="volunteering"
+          routerLinkActive="active"
+          ariaCurrentWhenActive="page"
+        >
+          Volunteering
+        </button>
+      </li>
+      <li class="nav-item">
+        <button
+          tabindex="0"
+          class="nav-link"
           routerLink="about"
           routerLinkActive="active"
           ariaCurrentWhenActive="page"

--- a/src/app/volunteering/volunteering.component.css
+++ b/src/app/volunteering/volunteering.component.css
@@ -1,0 +1,39 @@
+h2 {
+  text-align: center;
+  color: rgb(222, 187, 255);
+}
+
+p, li {
+  font-family: MoreSugar;
+  font-style: italic;
+  font-weight: 700;
+}
+
+.volunteering-date {
+  text-align: center;
+  color: rgb(181, 111, 216);
+}
+
+.volunteering-org {
+  text-align: center;
+  color: rgb(180, 180, 180);
+}
+
+.volunteering-cause {
+  text-align: center;
+  color: rgb(180, 180, 180);
+  font-size: 0.9em;
+}
+
+.volunteering-section {
+  padding: 0.75em;
+  margin: 1em;
+  border-radius: 15px;
+  background: rgba(163, 163, 163);
+  background: linear-gradient(
+    90deg,
+    rgb(107, 107, 107, 1) 0%,
+    rgba(181, 111, 216, 0.2) 47%,
+    rgb(68, 114, 126, 0.5) 100%
+  );
+}

--- a/src/app/volunteering/volunteering.component.html
+++ b/src/app/volunteering/volunteering.component.html
@@ -1,0 +1,246 @@
+<div class="row justify-content-center mb-3">
+  <div class="col-12">
+    <h2 tabindex="0">Where does the Usi give back?</h2>
+  </div>
+</div>
+
+<!-- Civil Rights and Social Action -->
+<div class="row justify-content-center mb-2 mt-4">
+  <div class="col-12">
+    <h2 tabindex="0">Civil Rights and Social Action</h2>
+  </div>
+</div>
+<div class="row justify-content-center">
+  <div class="col-12 col-md-10 col-lg-5 volunteering-section">
+    <h2 tabindex="0">Health and Safety Specialist</h2>
+    <p class="volunteering-org" tabindex="0">The Pride Center of Maryland</p>
+    <p class="volunteering-date" tabindex="0">May 2024 – Jul 2024 · 3 mos</p>
+    <p tabindex="0">2024 Baltimore City Pride Week Safety and Wellness Volunteer Staff</p>
+    <ul tabindex="0">
+      <li>Attended orientation.</li>
+      <li>Worked two approximately six-hour shifts in Safety and Wellness.</li>
+      <li>Patrolled grounds.</li>
+      <li>Took participant safety complaint reports.</li>
+      <li>Worked with hired security and Baltimore City Police to resolve safety concerns.</li>
+      <li>Triaged minor health concerns.</li>
+      <li>
+        Monitored the area for illicit drug use and adult materials from a safety perspective to
+        anticipate needs, provide hydration, and keep adult-oriented activity in areas away from
+        minors and non-consensual or unwitting observation.
+      </li>
+      <li>Gave directions.</li>
+      <li>Couriered emergency aid equipment and materials.</li>
+      <li>Observed press policy.</li>
+    </ul>
+  </div>
+
+  <div class="col-12 col-md-10 col-lg-5 volunteering-section">
+    <h2 tabindex="0">Lead Software Development Engineer</h2>
+    <p class="volunteering-org" tabindex="0">Neurodiversity in Business (NiB)</p>
+    <p class="volunteering-date" tabindex="0">Feb 2023 – Jun 2023 · 5 mos</p>
+    <p tabindex="0">
+      NiB is a business-led forum functioning as an industry group for organisations to share
+      industry good practice on neurodivergent recruitment, retention, and empowerment.
+    </p>
+    <p tabindex="0">
+      The vision is to foster a corporate environment where neurodivergent people are understood
+      and form an invaluable part of the work culture.
+    </p>
+    <p tabindex="0">
+      <a href="https://www.neurodiversityinbusiness.org" target="_blank" rel="noopener noreferrer">
+        Neurodiversity in Business
+      </a>
+    </p>
+  </div>
+
+  <div class="col-12 col-md-10 col-lg-5 volunteering-section">
+    <h2 tabindex="0">Parliamentarian</h2>
+    <p class="volunteering-org" tabindex="0">SSA Headquarters LGBT Advisory Committee</p>
+    <p class="volunteering-date" tabindex="0">2016 – 2019 · 3 yrs</p>
+    <p tabindex="0">
+      The Lesbian Gay Bisexual Transgender Advisory Committee (LGBTAC) provides assistance and
+      advice to the Commissioner regarding discrimination against the LGBT communities, advocates
+      for the civil rights of persons with AIDS/HIV, and educates the LGBT communities about a
+      diverse range of issues that impact their communities.
+    </p>
+    <p tabindex="0">
+      The parliamentarian advises the HQ LGBTAC Chair on proceedings according to Robert's Rules
+      of Order.
+    </p>
+  </div>
+</div>
+
+<!-- Economic Empowerment -->
+<div class="row justify-content-center mb-2 mt-4">
+  <div class="col-12">
+    <h2 tabindex="0">Economic Empowerment</h2>
+  </div>
+</div>
+<div class="row justify-content-center">
+  <div class="col-12 col-md-10 col-lg-5 volunteering-section">
+    <h2 tabindex="0">Chairperson</h2>
+    <p class="volunteering-org" tabindex="0">Securityplus Federal Credit Union</p>
+    <p class="volunteering-date" tabindex="0">2017 – Apr 2021 · 4 yrs 4 mos</p>
+    <p tabindex="0">
+      Supervisory Committee Member at Security Plus Federal Credit Union. Part 715 of the NCUA
+      Rules and Regulations defines a supervisory committee consistent with Section 111(b) of the
+      Federal Credit Union Act, 12 U.S.C. 1786(r).
+    </p>
+    <ul tabindex="0">
+      <li>Reviewed internal controls.</li>
+      <li>Hired and worked with an internal auditor.</li>
+      <li>Hired and worked with the external auditor.</li>
+      <li>
+        Reviewed examination and audit findings and followed up to ensure that management took
+        the necessary corrective action.
+      </li>
+      <li>Met with the federal examiner as requested.</li>
+      <li>Researched member complaints.</li>
+      <li>Completed other procedures recommended by the SC and board.</li>
+      <li>
+        Sat in on board meetings, reported on SC motions to the board, and reported to the
+        internal auditor on board meeting motions.
+      </li>
+    </ul>
+    <p tabindex="0">
+      <a
+        href="https://www.securityplusfcu.org/community/baltimores-community-credit-union.aspx"
+        target="_blank"
+        rel="noopener noreferrer"
+      >Securityplus Federal Credit Union | Baltimore, MD</a>
+    </p>
+  </div>
+</div>
+
+<!-- Science and Technology -->
+<div class="row justify-content-center mb-2 mt-4">
+  <div class="col-12">
+    <h2 tabindex="0">Science and Technology</h2>
+  </div>
+</div>
+<div class="row justify-content-center">
+  <div class="col-12 col-md-10 col-lg-5 volunteering-section">
+    <h2 tabindex="0">Information Technology Risk Manager</h2>
+    <p class="volunteering-org" tabindex="0">Securityplus Federal Credit Union</p>
+    <p class="volunteering-date" tabindex="0">2017 – Jul 2020 · 3 yrs 7 mos</p>
+    <p tabindex="0">
+      The purpose of the committee is to serve as an extension of the Credit Union Board of
+      Directors in matters related to information systems technology; and to provide feedback to
+      the board and management on matters which may need to be evaluated, and in the case of
+      risks, mitigated and/or monitored, in accordance with NCUA rules and regulations.
+    </p>
+    <p tabindex="0">
+      The SC representative reports to the SFCU internal auditor as to relevant discussions
+      conducted and motions passed by the ISRMC.
+    </p>
+    <p tabindex="0">
+      <a
+        href="https://www.securityplusfcu.org/community/baltimores-community-credit-union.aspx"
+        target="_blank"
+        rel="noopener noreferrer"
+      >Securityplus Federal Credit Union | Baltimore, MD</a>
+    </p>
+  </div>
+</div>
+
+<!-- Arts and Culture -->
+<div class="row justify-content-center mb-2 mt-4">
+  <div class="col-12">
+    <h2 tabindex="0">Arts and Culture</h2>
+  </div>
+</div>
+<div class="row justify-content-center">
+  <div class="col-12 col-md-10 col-lg-5 volunteering-section">
+    <h2 tabindex="0">Opera Singer</h2>
+    <p class="volunteering-org" tabindex="0">Life Care Services</p>
+    <p class="volunteering-date" tabindex="0">2012 – 2015 · 3 yrs</p>
+    <p tabindex="0">
+      Performed a collection of lieder, arias, and musical theater works centering around
+      Schubert, Bernstein, Verdi, Leoncavallo, and other popular tunes for residents.
+    </p>
+  </div>
+
+  <div class="col-12 col-md-10 col-lg-5 volunteering-section">
+    <h2 tabindex="0">Performing Artist</h2>
+    <p class="volunteering-org" tabindex="0">The Audrey Herman Spotlighters Theatre</p>
+    <p class="volunteering-date" tabindex="0">2009 – 2014 · 5 yrs</p>
+    <p tabindex="0">
+      Performed a variety of lead, supporting, and chorister roles and occasionally did
+      non-musical acting.
+    </p>
+    <ul tabindex="0">
+      <li>
+        Chorus and supporting roles —
+        <a href="https://www.spotlighters.org/jekyll-hyde14-15.html" target="_blank" rel="noopener noreferrer">Jekyll and Hyde</a>
+      </li>
+      <li>
+        Henrik —
+        <a href="https://www.spotlighters.org/a-little-night-music10-11.html" target="_blank" rel="noopener noreferrer">A Little Night Music</a>
+      </li>
+      <li>Herald/Chorus — Rodgers and Hammerstein's Cinderella</li>
+      <li>
+        Pirelli —
+        <a href="http://www.abouttheartists.com/productions/14047-the-tale-of-sweeney-todd-the-demon-barber-of-fleet-street-at-the-audrey-herman-spotlighters-theatre-march-20-april-19-2009" target="_blank" rel="noopener noreferrer">Sondheim's Sweeney Todd</a>
+      </li>
+      <li>Chorus and supporting roles — Cabaret</li>
+      <li>Supporting roles — Stage Blood</li>
+    </ul>
+  </div>
+
+  <div class="col-12 col-md-10 col-lg-5 volunteering-section">
+    <h2 tabindex="0">Tenor Soloist and Chorister</h2>
+    <p class="volunteering-org" tabindex="0">Greenspring Valley Orchestra · Stevenson University</p>
+    <p class="volunteering-date" tabindex="0">2004 – 2015 · 11 yrs</p>
+    <p tabindex="0">
+      The orchestra is one of the most respected amateur organizations of its type in the Baltimore
+      area, performing winter and spring concerts as well as a popular outdoor summer series —
+      an advanced ensemble specializing in standard classics and pop favorites.
+    </p>
+    <ul tabindex="0">
+      <li>Mozart's Requiem</li>
+      <li>Scenes from Mozart's Così fan tutte</li>
+      <li>Scenes from Massenet's Werther</li>
+      <li>Scenes from La Bohème</li>
+      <li>Scenes from Puccini's Tosca</li>
+    </ul>
+  </div>
+
+  <div class="col-12 col-md-10 col-lg-5 volunteering-section">
+    <h2 tabindex="0">Opera Singer</h2>
+    <p class="volunteering-org" tabindex="0">Young Victorian Theatre Company</p>
+    <p class="volunteering-date" tabindex="0">2009 · Less than a year</p>
+    <p tabindex="0">
+      Small seasonal opera company performing Victorian Era Operetta. Served as Tenor I for their
+      seasonal performance of Gilbert and Sullivan's Pirates of Penzance.
+    </p>
+  </div>
+
+  <div class="col-12 col-md-10 col-lg-5 volunteering-section">
+    <h2 tabindex="0">Performing Artist</h2>
+    <p class="volunteering-org" tabindex="0">Baltimore Playwrights Festival</p>
+    <p class="volunteering-date" tabindex="0">2010 – Present · 16 yrs 4 mos</p>
+    <p tabindex="0">
+      <a
+        href="https://www.broadwayworld.com/baltimore/article/Spotlighters-Theatre-Baltimore-Playwrights-Festival-Present-HAMMARSKJOLD-812-20100812"
+        target="_blank"
+        rel="noopener noreferrer"
+      >McKinney's Hammarskjold</a>
+      — Directed by veteran director Lynn Morton, Fr. McKinney's Hammarskjold tells the story of
+      a man who awakens after a beating in Central Park convinced he is Dag Hammarskjold and
+      suspected by the police of murder.
+    </p>
+  </div>
+
+  <div class="col-12 col-md-10 col-lg-5 volunteering-section">
+    <h2 tabindex="0">Opera Singer</h2>
+    <p class="volunteering-org" tabindex="0">Opera Vivente</p>
+    <p class="volunteering-date" tabindex="0">2009 · Less than a year</p>
+    <p tabindex="0">
+      <a
+        href="https://conductingmasterclass.wordpress.com/2009/09/29/opera-vivente-stages-rossinis-cinderella/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >An English production of Rossini's Cenerentola.</a>
+    </p>
+  </div>
+</div>

--- a/src/app/volunteering/volunteering.component.spec.ts
+++ b/src/app/volunteering/volunteering.component.spec.ts
@@ -1,0 +1,115 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { VolunteeringComponent } from './volunteering.component';
+
+describe('VolunteeringComponent', () => {
+  let component: VolunteeringComponent;
+  let fixture: ComponentFixture<VolunteeringComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [VolunteeringComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(VolunteeringComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should have id="maincontent" as a skip link target', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.getAttribute('id')).toBe('maincontent');
+  });
+
+  it('should render volunteering section cards', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const sections = el.querySelectorAll('.volunteering-section');
+    expect(sections.length).toBeGreaterThan(0);
+  });
+
+  it('should render all eleven volunteering entries', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const sections = el.querySelectorAll('.volunteering-section');
+    expect(sections.length).toBe(11);
+  });
+
+  it('should display all four category section headings', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const text = el.textContent ?? '';
+    expect(text).toContain('Civil Rights and Social Action');
+    expect(text).toContain('Economic Empowerment');
+    expect(text).toContain('Science and Technology');
+    expect(text).toContain('Arts and Culture');
+  });
+
+  it('should have keyboard-accessible headings', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const headings = el.querySelectorAll('h2[tabindex]');
+    expect(headings.length).toBeGreaterThan(0);
+    headings.forEach((h) => {
+      expect(h.getAttribute('tabindex')).toBe('0');
+    });
+  });
+
+  it('should have keyboard-accessible text content', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const paragraphs = el.querySelectorAll('p[tabindex]');
+    expect(paragraphs.length).toBeGreaterThan(0);
+    paragraphs.forEach((p) => {
+      expect(p.getAttribute('tabindex')).toBe('0');
+    });
+  });
+
+  it('should contain the Health and Safety Specialist entry', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.textContent).toContain('Health and Safety Specialist');
+    expect(el.textContent).toContain('The Pride Center of Maryland');
+  });
+
+  it('should contain the Neurodiversity in Business volunteer role', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.textContent).toContain('Lead Software Development Engineer');
+    expect(el.textContent).toContain('Neurodiversity in Business');
+  });
+
+  it('should contain the SSA LGBTAC parliamentarian role', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.textContent).toContain('Parliamentarian');
+    expect(el.textContent).toContain('SSA Headquarters LGBT Advisory Committee');
+  });
+
+  it('should contain the Securityplus Federal Credit Union roles', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.textContent).toContain('Chairperson');
+    expect(el.textContent).toContain('Information Technology Risk Manager');
+    expect(el.textContent).toContain('Securityplus Federal Credit Union');
+  });
+
+  it('should contain arts and culture performing entries', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.textContent).toContain('Life Care Services');
+    expect(el.textContent).toContain('The Audrey Herman Spotlighters Theatre');
+    expect(el.textContent).toContain('Greenspring Valley Orchestra');
+    expect(el.textContent).toContain('Young Victorian Theatre Company');
+    expect(el.textContent).toContain('Baltimore Playwrights Festival');
+    expect(el.textContent).toContain('Opera Vivente');
+  });
+
+  it('should include external links for referenced organisations', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const links = el.querySelectorAll('a[href]');
+    expect(links.length).toBeGreaterThan(0);
+  });
+
+  it('should open external links safely with rel="noopener noreferrer"', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const externalLinks = el.querySelectorAll('a[target="_blank"]');
+    externalLinks.forEach((link) => {
+      expect(link.getAttribute('rel')).toContain('noopener');
+      expect(link.getAttribute('rel')).toContain('noreferrer');
+    });
+  });
+});

--- a/src/app/volunteering/volunteering.component.ts
+++ b/src/app/volunteering/volunteering.component.ts
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: '[volunteering]',
+  host: {
+    id: 'maincontent',
+    class: 'container mt-1 mb-5',
+    style: 'background-color: rgba(255, 255, 255, 0.096); border-radius: 25px;',
+  },
+  imports: [],
+  templateUrl: './volunteering.component.html',
+  styleUrl: './volunteering.component.css',
+})
+export class VolunteeringComponent {}


### PR DESCRIPTION
## Summary
- Extend \`generate-summary.js\` to also write the markdown summary to \`integration-tests-report/pr-comment.md\` (and include a link back to the full workflow run so readers can click through to the Job Summary tab with screenshot thumbnails).
- New \`integration-tests.yml\` step using \`marocchino/sticky-pull-request-comment@v2\` posts that markdown as a PR comment on \`pull_request\` runs. Uses \`header: integration-tests\` so re-runs edit the same comment instead of stacking new ones.
- Runs with \`if: always()\` so failed runs still post results.
- Comment size ~7 KB — well under GitHub's 65 KB limit (no base64 images).
- Uses the existing \`pull-requests: write\` permission; no token or secret changes needed.

## Test plan
- [x] Run \`generate-summary.js\` locally against an existing cucumber-report.json — writes \`pr-comment.md\` at ~7 KB with a run link and artifact link
- [ ] CI posts the comment on this PR when integration tests finish
- [ ] Re-running the workflow updates the same comment rather than adding a new one

🤖 Generated with [Claude Code](https://claude.com/claude-code)