### PR TITLE
Copy review, floating skill chips, and education follow-ups

### DIFF
--- a/e2e/features/education.feature
+++ b/e2e/features/education.feature
@@ -17,6 +17,5 @@ Feature: Education Page
       | Licenses & Certifications                                 |
       | Adult and Pediatric First Aid/CPR/AED                     |
       | Basic Life Support for Healthcare and Public Safety (BLS) |
-      | Certified Tutor                                           |
       | Introduction to R Course                                  |
       | Certified Advanced Tutor                                  |

--- a/src/app/education/education.component.css
+++ b/src/app/education/education.component.css
@@ -26,12 +26,35 @@ li {
   color: rgb(180, 180, 180);
 }
 
+/* Skills row: equidistant floating chips pinned to the bottom of each card. */
 .education-skills {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-around;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: auto;
+  padding-top: 0.6rem;
+}
+
+.education-skill {
+  flex: 0 1 auto;
+  padding: 0.2rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(181, 111, 216, 0.25);
+  border: 1px solid rgba(181, 111, 216, 0.5);
+  color: rgb(222, 187, 255);
+  font-family: MoreSugar;
+  font-style: italic;
+  font-weight: 700;
+  font-size: 0.82rem;
   text-align: center;
-  color: rgb(180, 180, 180);
+  white-space: nowrap;
 }
 
 .education-section {
+  display: flex;
+  flex-direction: column;
   padding: 0.75em;
   margin: 1em;
   border-radius: 15px;

--- a/src/app/education/education.component.html
+++ b/src/app/education/education.component.html
@@ -23,9 +23,32 @@
       adjudicated thesis project.
     </p>
     <div class="education-skills" tabindex="0" aria-label="Skills">
-      <div class="education-skill">Mathematical Modeling</div>
-      <div class="education-skill">Advanced Linear Algebra</div>
-      <div class="education-skill">Tensors</div>
+      <span class="education-skill">Mathematical Modeling</span>
+      <span class="education-skill">Advanced Linear Algebra</span>
+      <span class="education-skill">Tensors</span>
+      <span class="education-skill">Maven</span>
+      <span class="education-skill">Emulation</span>
+      <span class="education-skill">Stage Combat</span>
+      <span class="education-skill">Data Science</span>
+      <span class="education-skill">Training</span>
+      <span class="education-skill">Sight Reading</span>
+      <span class="education-skill">Software Development Life Cycle (SDLC)</span>
+      <span class="education-skill">Theatrical Production</span>
+      <span class="education-skill">Music Performance</span>
+      <span class="education-skill">Security</span>
+      <span class="education-skill">Technical Documentation</span>
+      <span class="education-skill">Creativity Skills</span>
+      <span class="education-skill">Public Speaking</span>
+      <span class="education-skill">Musical Theatre</span>
+      <span class="education-skill">Cryptography</span>
+      <span class="education-skill">Singing</span>
+      <span class="education-skill">Java</span>
+      <span class="education-skill">Red Hat Enterprise Linux</span>
+      <span class="education-skill">C++</span>
+      <span class="education-skill">Acting</span>
+      <span class="education-skill">Vocal Music</span>
+      <span class="education-skill">JavaScript</span>
+      <span class="education-skill">Linux</span>
     </div>
   </div>
 
@@ -42,8 +65,8 @@
       Bellini, Donizetti, Puccini, and Mozart operas.
     </p>
     <div class="education-skills" tabindex="0" aria-label="Skills">
-      <div class="education-skill">Music Performance</div>
-      <div class="education-skill">Vocal Music</div>
+      <span class="education-skill">Music Performance</span>
+      <span class="education-skill">Vocal Music</span>
     </div>
   </div>
 
@@ -56,7 +79,7 @@
       Development in a Mainframe environment.
     </p>
     <div class="education-skills" tabindex="0" aria-label="Skills">
-      <div class="education-skill">WebSphere Application Server</div>
+      <span class="education-skill">WebSphere Application Server</span>
     </div>
   </div>
 </div>
@@ -75,8 +98,10 @@
     </p>
     <p tabindex="0">Credential ID: 022T2NJ</p>
     <div class="education-skills" tabindex="0" aria-label="Skills">
-      <div class="education-skill">Adult CPR</div>
-      <div class="education-skill">First Aid</div>
+      <span class="education-skill">Adult CPR</span>
+      <span class="education-skill">First Aid</span>
+      <span class="education-skill">Wound Care</span>
+      <span class="education-skill">Pediatric CPR</span>
     </div>
   </div>
 
@@ -90,29 +115,12 @@
     </p>
     <p tabindex="0">Credential ID: 0226AN2</p>
     <div class="education-skills" tabindex="0" aria-label="Skills">
-      <div class="education-skill">Cardiopulmonary Resuscitation (CPR)</div>
-      <div class="education-skill">Pediatric CPR</div>
-    </div>
-  </div>
-
-  <div class="col-12 col-md-10 col-lg-5 education-section">
-    <h2 tabindex="0">Certified Tutor</h2>
-    <p class="education-org" tabindex="0">
-      International TUTOR Training Program Certification (ITTPC)
-    </p>
-    <div class="education-skills" tabindex="0" aria-label="Skills">
-      <div class="education-skill">Training</div>
-      <div class="education-skill">Java</div>
-    </div>
-  </div>
-
-  <div class="col-12 col-md-10 col-lg-5 education-section">
-    <h2 tabindex="0">Introduction to R Course</h2>
-    <p class="education-org" tabindex="0">DataCamp</p>
-    <p tabindex="0">Credential ID: 4361292</p>
-    <div class="education-skills" tabindex="0" aria-label="Skills">
-      <div class="education-skill">R</div>
-      <div class="education-skill">Technical Documentation</div>
+      <span class="education-skill">Adult CPR</span>
+      <span class="education-skill">First Aid</span>
+      <span class="education-skill">Wound Care</span>
+      <span class="education-skill">Pediatric CPR</span>
+      <span class="education-skill">Team Resuscitation</span>
+      <span class="education-skill">Healthcare Setting Response Team</span>
     </div>
   </div>
 
@@ -122,8 +130,22 @@
       International TUTOR Training Program Certification (ITTPC)
     </p>
     <div class="education-skills" tabindex="0" aria-label="Skills">
-      <div class="education-skill">Training</div>
-      <div class="education-skill">Java</div>
+      <span class="education-skill">Training</span>
+      <span class="education-skill">Java</span>
+      <span class="education-skill">College Engineering Math</span>
+      <span class="education-skill">College-Level Physics with Calculus</span>
     </div>
   </div>
+
+  <div class="col-12 col-md-10 col-lg-5 education-section">
+    <h2 tabindex="0">Introduction to R Course</h2>
+    <p class="education-org" tabindex="0">DataCamp</p>
+    <p tabindex="0">Credential ID: 4361292</p>
+    <div class="education-skills" tabindex="0" aria-label="Skills">
+      <span class="education-skill">R</span>
+      <span class="education-skill">Technical Documentation</span>
+      <span class="education-skill">Data Science</span>
+    </div>
+  </div>
+
 </div>

--- a/src/app/education/education.component.html
+++ b/src/app/education/education.component.html
@@ -7,8 +7,8 @@
   <div class="col-12 col-md-10 col-lg-5 education-section">
     <h2 tabindex="0">Stevenson University</h2>
     <p class="education-degree" tabindex="0">
-      B.S. Interdiciplinary Studies (CIS/Applied Mathematics), Mathematical
-      Modeling and Information Retrival
+      B.S. Interdisciplinary Studies (CIS/Applied Mathematics), Mathematical
+      Modeling and Information Retrieval
     </p>
     <p tabindex="0">
       Activities and societies: Tutor, International mathematical modeling
@@ -22,9 +22,11 @@
       advanced mathematics, and an extended joint Mathematics &amp; CIS
       adjudicated thesis project.
     </p>
-    <p class="education-skills" tabindex="0">
-      Skills: Mathematical Modeling, Advanced Linear Algebra, Tensors
-    </p>
+    <div class="education-skills" tabindex="0" aria-label="Skills">
+      <div class="education-skill">Mathematical Modeling</div>
+      <div class="education-skill">Advanced Linear Algebra</div>
+      <div class="education-skill">Tensors</div>
+    </div>
   </div>
 
   <div class="col-12 col-md-10 col-lg-5 education-section">
@@ -39,9 +41,10 @@
       tenor repertoire focused on lyric and spinto roles. Focused on Verdi,
       Bellini, Donizetti, Puccini, and Mozart operas.
     </p>
-    <p class="education-skills" tabindex="0">
-      Skills: Music Performance, Vocal Music
-    </p>
+    <div class="education-skills" tabindex="0" aria-label="Skills">
+      <div class="education-skill">Music Performance</div>
+      <div class="education-skill">Vocal Music</div>
+    </div>
   </div>
 
   <div class="col-12 col-md-10 col-lg-5 education-section">
@@ -52,9 +55,9 @@
       Activities and societies: Professional level training in Enterprise Java
       Development in a Mainframe environment.
     </p>
-    <p class="education-skills" tabindex="0">
-      Skills: WebSphere Application Server
-    </p>
+    <div class="education-skills" tabindex="0" aria-label="Skills">
+      <div class="education-skill">WebSphere Application Server</div>
+    </div>
   </div>
 </div>
 
@@ -71,7 +74,10 @@
       Issued Sep 2025 · Expires Sep 2027
     </p>
     <p tabindex="0">Credential ID: 022T2NJ</p>
-    <p class="education-skills" tabindex="0">Skills: Adult CPR, First Aid</p>
+    <div class="education-skills" tabindex="0" aria-label="Skills">
+      <div class="education-skill">Adult CPR</div>
+      <div class="education-skill">First Aid</div>
+    </div>
   </div>
 
   <div class="col-12 col-md-10 col-lg-5 education-section">
@@ -83,9 +89,10 @@
       Issued Sep 2025 · Expires Sep 2027
     </p>
     <p tabindex="0">Credential ID: 0226AN2</p>
-    <p class="education-skills" tabindex="0">
-      Skills: Cardiopulmonary Resuscitation (CPR), Pediatric CPR,
-    </p>
+    <div class="education-skills" tabindex="0" aria-label="Skills">
+      <div class="education-skill">Cardiopulmonary Resuscitation (CPR)</div>
+      <div class="education-skill">Pediatric CPR</div>
+    </div>
   </div>
 
   <div class="col-12 col-md-10 col-lg-5 education-section">
@@ -93,16 +100,20 @@
     <p class="education-org" tabindex="0">
       International TUTOR Training Program Certification (ITTPC)
     </p>
-    <p class="education-skills" tabindex="0">Skills: Training, Java,</p>
+    <div class="education-skills" tabindex="0" aria-label="Skills">
+      <div class="education-skill">Training</div>
+      <div class="education-skill">Java</div>
+    </div>
   </div>
 
   <div class="col-12 col-md-10 col-lg-5 education-section">
     <h2 tabindex="0">Introduction to R Course</h2>
     <p class="education-org" tabindex="0">DataCamp</p>
     <p tabindex="0">Credential ID: 4361292</p>
-    <p class="education-skills" tabindex="0">
-      Skills: R, Technical Documentation,
-    </p>
+    <div class="education-skills" tabindex="0" aria-label="Skills">
+      <div class="education-skill">R</div>
+      <div class="education-skill">Technical Documentation</div>
+    </div>
   </div>
 
   <div class="col-12 col-md-10 col-lg-5 education-section">
@@ -110,6 +121,9 @@
     <p class="education-org" tabindex="0">
       International TUTOR Training Program Certification (ITTPC)
     </p>
-    <p class="education-skills" tabindex="0">Skills: Training, Java,</p>
+    <div class="education-skills" tabindex="0" aria-label="Skills">
+      <div class="education-skill">Training</div>
+      <div class="education-skill">Java</div>
+    </div>
   </div>
 </div>

--- a/src/app/education/education.component.spec.ts
+++ b/src/app/education/education.component.spec.ts
@@ -77,11 +77,6 @@ describe('EducationComponent', () => {
     );
   });
 
-  it('should contain the Certified Tutor certification', () => {
-    const el: HTMLElement = fixture.nativeElement;
-    expect(el.textContent).toContain('Certified Tutor');
-  });
-
   it('should contain the Introduction to R Course certification', () => {
     const el: HTMLElement = fixture.nativeElement;
     expect(el.textContent).toContain('Introduction to R Course');

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -50,7 +50,7 @@
             vertical-align: text-bottom;
           "
           src="https://mirrors.creativecommons.org/presskit/icons/zero.svg?ref=chooser-v1"
-          alt="Create Commons Zero Press Kit"
+          alt="Creative Commons Zero Press Kit"
       /></a>
     </p>
   </div>

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -3,11 +3,11 @@
     <h2 tabindex="0">What is an Usi?</h2>
     <p tabindex="0">
       It is a queer, autistic, trans and non-binary, autodidactic developer as
-      well as a life long Linux desktop geek, and impassioned mathematics
+      well as a lifelong Linux desktop geek, and impassioned mathematics
       enthusiast.
     </p>
     <p tabindex="0">
-      Its expertise surrounds a litany of web application standards, languages,
+      Its expertise covers a litany of web application standards, languages,
       libraries, protocols, and system security patterns.
     </p>
     <p tabindex="0">
@@ -27,7 +27,7 @@
     <p tabindex="0">
       Members of the Usi System use <span class="pronouns">'It'</span>,
       <span class="pronouns">'We'</span>, and sometimes rarely
-      <span class="pronouns">'I'</span> as <u>first person pronouns</u> in
+      <span class="pronouns">'I'</span> as <u>first-person pronouns</u> in
       speech and text.
     </p>
     <p tabindex="-1" class="text-center">
@@ -76,7 +76,7 @@
   <div section>
     <div question>What causes does it care about?</div>
     <div content>
-      <p>It enjoys helping Non-profit efforts in</p>
+      <p>It enjoys helping non-profit efforts in:</p>
       <ul>
         <li>LGBTQIA+ Civil Rights.</li>
         <li>Neurodiversity.</li>
@@ -97,7 +97,7 @@
       <p>In gaming, it enjoys</p>
       <ul>
         <li>Third-person RPGs.</li>
-        <li>JROPGs.</li>
+        <li>JRPGs.</li>
         <li>
           TTRPGs playing and GMing since 1999.
           <ul>
@@ -127,8 +127,8 @@
     <div question>What does the Usi do for money?</div>
     <div content>
       <p>
-        It has been a professional full stack developer for over 13 years. It is
-        responsible for:
+        It has been a professional full-stack developer for over 13 years. It
+        is responsible for:
       </p>
       <ul>
         <li>
@@ -136,7 +136,7 @@
           Auditing Online Self-Service Application Design/Modification.
         </li>
         <li>Analyzing and Refining Systems Requirements.</li>
-        <li>Code Level Security Implimentation, Design, and Maitenance.</li>
+        <li>Code-Level Security Implementation, Design, and Maintenance.</li>
         <li>Secure DevOps Environment Development.</li>
         <li>Cloud Migration.</li>
         <li>Enterprise Architecture.</li>

--- a/src/app/volunteering/volunteering.component.html
+++ b/src/app/volunteering/volunteering.component.html
@@ -29,10 +29,10 @@
       </li>
       <li>Triaged minor health concerns.</li>
       <li>
-        Monitored the area for illicit drug use and adult materials from a
-        safety perspective to anticipate needs, provide hydration, and keep
-        adult-oriented activity in areas away from minors and non-consensual or
-        unwitting observation.
+        Monitored the area for illicit drug use and for adult-oriented activity
+        from a safety perspective, to anticipate needs, provide hydration, and
+        keep adult-oriented activity in areas away from minors and non-consensual
+        or unwitting observation.
       </li>
       <li>Gave directions.</li>
       <li>Couriered emergency aid equipment and materials.</li>


### PR DESCRIPTION
## Summary

A scan of the site copy for grammatical errors (respecting the intentional third-person \"it/we\" self-reference), plus a layout refactor of the Skills lines and a wave of education-card edits.

## Copy fixes

- [home.component.html](src/app/home/home.component.html)
  - \"life long\" → \"lifelong\"
  - \"Its expertise surrounds\" → \"Its expertise covers\"
  - \"It enjoys helping Non-profit efforts in\" → \"It enjoys helping non-profit efforts in:\" (colon introduces the list)
  - \"first person pronouns\" → \"first-person pronouns\"
  - \"professional full stack developer\" → \"professional full-stack developer\"
  - \"Code Level Security Implimentation, Design, and Maitenance\" → \"Code-Level Security Implementation, Design, and Maintenance\"
  - \"JROPGs\" → \"JRPGs\"
- [education.component.html](src/app/education/education.component.html)
  - \"Interdiciplinary\" → \"Interdisciplinary\"
  - \"Retrival\" → \"Retrieval\"
- [footer.component.html](src/app/footer/footer.component.html)
  - img alt \"Create Commons Zero Press Kit\" → \"Creative Commons Zero Press Kit\"
- [volunteering.component.html](src/app/volunteering/volunteering.component.html)
  - Parallelise the Pride Week safety bullet so the two things being monitored (\"illicit drug use\" and \"adult-oriented activity\") both read naturally after \"monitored the area for ... and for ...\"

The intentional third-person self-reference pattern (\"it\"/\"we\") is preserved throughout — no case was found where \"It\" should have been \"I\".

## Floating Skills chip rows (education cards)

The old \"Skills: A, B, C,\" sentences (several had dangling trailing commas) are gone. Each card now renders its skills as an equidistantly-spaced row of pill chips pinned to the bottom:

- Each chip is a \`<span class=\"education-skill\">\` inside a \`<div class=\"education-skills\" aria-label=\"Skills\">\`
- Chips flex-wrap + space-around so they space out evenly on wide viewports and wrap cleanly on narrow ones
- \`.education-section\` is now a flex column with \`margin-top: auto\` on \`.education-skills\`, so the chip row sits at the bottom of the card regardless of how much paragraph copy sits above

## Education card content changes

- **Stevenson University**: skill row extended with Maven, Emulation, Stage Combat, Data Science, Training, Sight Reading, SDLC, Theatrical Production, Music Performance, Security, Technical Documentation, Creativity Skills, Public Speaking, Musical Theatre, Cryptography, Singing, Java, Red Hat Enterprise Linux, C++, Acting, Vocal Music, JavaScript, Linux — alongside the existing Mathematical Modeling / Advanced Linear Algebra / Tensors
- **Adult and Pediatric First Aid/CPR/AED**: skills now Adult CPR, First Aid, Wound Care, Pediatric CPR
- **Basic Life Support (BLS)**: skills now Adult CPR, First Aid, Wound Care, Pediatric CPR, Team Resuscitation, Healthcare Setting Response Team
- **Introduction to R Course**: Data Science added alongside R and Technical Documentation
- **Certified Tutor / Certified Advanced Tutor**: collapsed into a single Certified Advanced Tutor card carrying Training, Java, College Engineering Math, College-Level Physics with Calculus

## Tests

- Unit: 104/104 passing. Dropped the stale \`should contain the Certified Tutor certification\` spec (covered implicitly by the \`Certified Advanced Tutor\` spec).
- Integration: dropped the matching \`Certified Tutor\` row from \`education.feature\`'s entry scenario outline.

## Test plan
- [x] \`npm run build\` — production build clean
- [x] \`npm test -- --watch=false\` — 104/104 passing
- [ ] CI passes
- [x] Visual check: education/cert cards render the skill chips evenly spaced and pinned to the bottom of each card; copy fixes visible on Home / Education / Volunteering / Footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)