### PR TITLE
WebGL mist + lattice background

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -9,6 +9,7 @@
   >{{ 'common.skipToMainContent' | translate }}</a
 >
 
+<app-background></app-background>
 <header personal-header></header>
 <div menu></div>
 <div class="container-xl py-4">

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,6 +2,7 @@ import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
 
 import { AppRoutingModule, routes } from './app-routing.module';
 import { AppComponent } from './app.component';
+import { BackgroundComponent } from './background/background.component';
 import { BrowserModule } from '@angular/platform-browser';
 import {
   provideHttpClient,
@@ -22,7 +23,13 @@ import { LanguageService } from './i18n/language.service';
 import { LanguageSwitcherComponent } from './i18n/language-switcher/language-switcher.component';
 
 @NgModule({
-  declarations: [AppComponent, FooterComponent, HomeComponent, HeaderComponent],
+  declarations: [
+    AppComponent,
+    BackgroundComponent,
+    FooterComponent,
+    HomeComponent,
+    HeaderComponent,
+  ],
   imports: [
     BrowserModule,
     AppRoutingModule,

--- a/src/app/background/background.component.html
+++ b/src/app/background/background.component.html
@@ -1,0 +1,1 @@
+<canvas #canvas aria-hidden="true"></canvas>

--- a/src/app/background/background.component.scss
+++ b/src/app/background/background.component.scss
@@ -1,0 +1,18 @@
+@use 'tokens' as t;
+
+:host {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  display: block;
+  // Solid fallback so there's never a flash of white before GL initialises,
+  // and so the page is usable if WebGL is unavailable.
+  background: t.$charcoal;
+}
+
+canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}

--- a/src/app/background/background.component.ts
+++ b/src/app/background/background.component.ts
@@ -1,0 +1,255 @@
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  NgZone,
+  OnDestroy,
+  ViewChild,
+} from '@angular/core';
+
+const VERTEX_SHADER = `#version 100
+attribute vec2 a_position;
+void main() {
+  gl_Position = vec4(a_position, 0.0, 1.0);
+}`;
+
+// Mist + lattice fragment shader. Mist is a 2-pass warped fBm sampled in the
+// charcoal→purple→teal palette; lattice is a signed-distance grid that breathes
+// with slow time drift. Designed to feel cohesive with the diamond-card
+// palette rather than flashy.
+const FRAGMENT_SHADER = `#version 100
+precision highp float;
+
+uniform vec2 u_resolution;
+uniform float u_time;
+
+float hash(vec2 p) {
+  return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+}
+
+float valueNoise(vec2 p) {
+  vec2 i = floor(p);
+  vec2 f = fract(p);
+  vec2 u = f * f * (3.0 - 2.0 * f);
+  return mix(
+    mix(hash(i),             hash(i + vec2(1.0, 0.0)), u.x),
+    mix(hash(i + vec2(0.0, 1.0)), hash(i + vec2(1.0, 1.0)), u.x),
+    u.y
+  );
+}
+
+float fbm(vec2 p) {
+  float v = 0.0;
+  float a = 0.5;
+  for (int i = 0; i < 5; i++) {
+    v += a * valueNoise(p);
+    p *= 2.02;
+    a *= 0.5;
+  }
+  return v;
+}
+
+void main() {
+  vec2 uv = gl_FragCoord.xy / u_resolution.xy;
+  vec2 p = (gl_FragCoord.xy * 2.0 - u_resolution.xy) / min(u_resolution.x, u_resolution.y);
+
+  // -- Mist: domain-warped fBm ------------------------------------------------
+  vec2 q = vec2(
+    fbm(p * 1.1 + vec2(0.0, u_time * 0.03)),
+    fbm(p * 1.1 + vec2(5.2, u_time * 0.04))
+  );
+  float mist = fbm(p * 1.5 + q * 2.2 + vec2(u_time * 0.02, -u_time * 0.015));
+
+  // -- Lattice: soft grid lines with slow drift ------------------------------
+  vec2 gridP = p * 3.4 + vec2(u_time * 0.02, u_time * 0.015);
+  vec2 g = abs(fract(gridP) - 0.5);
+  float d = min(g.x, g.y);
+  float lattice = smoothstep(0.02, 0.0, d);
+
+  // Secondary lattice at 45deg for cross-hatch depth
+  vec2 r = mat2(0.7071, -0.7071, 0.7071, 0.7071) * gridP;
+  vec2 rg = abs(fract(r * 0.6) - 0.5);
+  float rlattice = smoothstep(0.015, 0.0, min(rg.x, rg.y));
+
+  // -- Palette (matches site tokens) ------------------------------------------
+  vec3 charcoal = vec3(0.278, 0.278, 0.278);
+  vec3 slate    = vec3(0.420, 0.420, 0.420);
+  vec3 purple   = vec3(0.710, 0.435, 0.847);
+  vec3 teal     = vec3(0.267, 0.447, 0.494);
+  vec3 lavender = vec3(0.871, 0.733, 1.000);
+
+  vec3 col = charcoal;
+  col = mix(col, slate,  smoothstep(0.2, 0.7, mist) * 0.55);
+  col = mix(col, purple, smoothstep(0.4, 0.85, mist) * 0.45);
+  col = mix(col, teal,   smoothstep(0.55, 0.95, mist) * 0.28);
+
+  // Vignette darkens edges so cards have contrast against the middle glow
+  float vignette = smoothstep(1.35, 0.25, length(uv - 0.5) * 1.9);
+  col *= mix(0.65, 1.0, vignette);
+
+  col += lavender * lattice * 0.18;
+  col += purple   * rlattice * 0.10;
+
+  gl_FragColor = vec4(col, 1.0);
+}`;
+
+@Component({
+  selector: 'app-background',
+  templateUrl: './background.component.html',
+  styleUrl: './background.component.scss',
+  standalone: false,
+})
+export class BackgroundComponent implements AfterViewInit, OnDestroy {
+  @ViewChild('canvas', { static: true })
+  private canvasRef!: ElementRef<HTMLCanvasElement>;
+
+  private gl: WebGLRenderingContext | null = null;
+  private program: WebGLProgram | null = null;
+  private rafId = 0;
+  private startTime = performance.now();
+  private resizeObserver?: ResizeObserver;
+  private motionQuery?: MediaQueryList;
+  private motionListener?: (e: MediaQueryListEvent) => void;
+  private uResolution: WebGLUniformLocation | null = null;
+  private uTime: WebGLUniformLocation | null = null;
+
+  constructor(private zone: NgZone) {}
+
+  ngAfterViewInit(): void {
+    const canvas = this.canvasRef.nativeElement;
+    const gl =
+      canvas.getContext('webgl', { antialias: false, depth: false }) ??
+      (canvas.getContext('experimental-webgl') as WebGLRenderingContext | null);
+
+    if (!gl) {
+      // Graceful fallback: leave the canvas empty; a static CSS background
+      // colour on <body> covers the viewport so the site remains usable.
+      return;
+    }
+    this.gl = gl;
+
+    const program = this.buildProgram(gl, VERTEX_SHADER, FRAGMENT_SHADER);
+    if (!program) return;
+    this.program = program;
+
+    const buffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+    // Full-screen triangle (covers the clip-space viewport in one draw call)
+    gl.bufferData(
+      gl.ARRAY_BUFFER,
+      new Float32Array([-1, -1, 3, -1, -1, 3]),
+      gl.STATIC_DRAW,
+    );
+
+    const aPosition = gl.getAttribLocation(program, 'a_position');
+    gl.enableVertexAttribArray(aPosition);
+    gl.vertexAttribPointer(aPosition, 2, gl.FLOAT, false, 0, 0);
+
+    this.uResolution = gl.getUniformLocation(program, 'u_resolution');
+    this.uTime = gl.getUniformLocation(program, 'u_time');
+    gl.useProgram(program);
+
+    this.resize();
+
+    if (typeof ResizeObserver !== 'undefined') {
+      this.resizeObserver = new ResizeObserver(() => this.resize());
+      this.resizeObserver.observe(canvas);
+    } else {
+      window.addEventListener('resize', this.resize);
+    }
+
+    this.motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    this.motionListener = () => {
+      cancelAnimationFrame(this.rafId);
+      if (!this.motionQuery?.matches) this.startLoop();
+      else this.renderFrame(0); // one static frame
+    };
+    this.motionQuery.addEventListener?.('change', this.motionListener);
+
+    if (this.motionQuery.matches) {
+      this.renderFrame(0);
+    } else {
+      this.startLoop();
+    }
+  }
+
+  ngOnDestroy(): void {
+    cancelAnimationFrame(this.rafId);
+    this.resizeObserver?.disconnect();
+    window.removeEventListener('resize', this.resize);
+    if (this.motionQuery && this.motionListener) {
+      this.motionQuery.removeEventListener?.('change', this.motionListener);
+    }
+  }
+
+  private startLoop(): void {
+    // Run the raf loop outside NgZone so it doesn't trigger change detection
+    // on every frame.
+    this.zone.runOutsideAngular(() => {
+      const tick = () => {
+        const t = (performance.now() - this.startTime) / 1000;
+        this.renderFrame(t);
+        this.rafId = requestAnimationFrame(tick);
+      };
+      this.rafId = requestAnimationFrame(tick);
+    });
+  }
+
+  private renderFrame(timeSec: number): void {
+    const gl = this.gl;
+    if (!gl || !this.program) return;
+    gl.uniform1f(this.uTime, timeSec);
+    gl.drawArrays(gl.TRIANGLES, 0, 3);
+  }
+
+  private resize = (): void => {
+    const gl = this.gl;
+    const canvas = this.canvasRef?.nativeElement;
+    if (!gl || !canvas) return;
+    // Cap DPR at 1.5 — the shader looks fine at lower density and saves
+    // meaningful GPU work on high-DPI phones/tablets.
+    const dpr = Math.min(window.devicePixelRatio || 1, 1.5);
+    const w = Math.floor(canvas.clientWidth * dpr);
+    const h = Math.floor(canvas.clientHeight * dpr);
+    if (canvas.width !== w || canvas.height !== h) {
+      canvas.width = w;
+      canvas.height = h;
+      gl.viewport(0, 0, w, h);
+    }
+    gl.uniform2f(this.uResolution, w, h);
+    this.renderFrame((performance.now() - this.startTime) / 1000);
+  };
+
+  private buildProgram(
+    gl: WebGLRenderingContext,
+    vsSource: string,
+    fsSource: string,
+  ): WebGLProgram | null {
+    const compile = (type: number, src: string): WebGLShader | null => {
+      const shader = gl.createShader(type);
+      if (!shader) return null;
+      gl.shaderSource(shader, src);
+      gl.compileShader(shader);
+      if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+        gl.deleteShader(shader);
+        return null;
+      }
+      return shader;
+    };
+
+    const vs = compile(gl.VERTEX_SHADER, vsSource);
+    const fs = compile(gl.FRAGMENT_SHADER, fsSource);
+    if (!vs || !fs) return null;
+
+    const program = gl.createProgram();
+    if (!program) return null;
+    gl.attachShader(program, vs);
+    gl.attachShader(program, fs);
+    gl.linkProgram(program);
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+      gl.deleteProgram(program);
+      return null;
+    }
+    return program;
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -88,7 +88,9 @@ h2 { font-size: clamp(1.25rem, 1.5vw + 0.75rem, 1.75rem); }
   }
 }
 
-// -- Animated background on <main app-root> ----------------------------------
+// -- App shell ---------------------------------------------------------------
+// Background art now lives in <app-background> (WebGL canvas, fixed, z-index 0)
+// so <main> is transparent over it.
 main {
   top: 0;
   position: absolute;
@@ -96,29 +98,12 @@ main {
   max-width: 100%;
   min-height: 100%;
   color: t.$gray;
-  background: t.$charcoal;
-
-  --y-0: 80%;
-  --x-0: 85%;
-  --c-0: hsla(266.99999999999983, 1%, 12%, 1);
-  --c-1: hsla(335.9999999999997, 2%, 22%, 1);
-  --y-1: 24%;
-  --x-1: 60%;
-  --x-2: 13%;
-  --c-2: hsla(53.999999999999886, 0%, 0%, 0.49);
-  --y-2: 82%;
-  --y-3: 7%;
-  --x-3: 24%;
-  --c-3: hsla(299, 4%, 36%, 1);
-
-  background-image:
-    radial-gradient(circle at var(--x-0) var(--y-0), var(--c-0) var(--s-start-0), transparent var(--s-end-0)),
-    radial-gradient(circle at var(--x-1) var(--y-1), var(--c-1) var(--s-start-1), transparent var(--s-end-1)),
-    radial-gradient(circle at var(--x-2) var(--y-2), var(--c-2) var(--s-start-2), transparent var(--s-end-2)),
-    radial-gradient(circle at var(--x-3) var(--y-3), var(--c-3) var(--s-start-3), transparent var(--s-end-3));
-  animation: gradient-animation 10s linear infinite alternate;
-  background-blend-mode: normal, normal, normal, normal;
+  background: transparent;
 }
+
+// Content sits above the fixed WebGL canvas
+app-background { z-index: 0; }
+header, [menu], .container-xl, footer { position: relative; z-index: 1; }
 
 // -- Shared page-card surface ------------------------------------------------
 .diamond-card {
@@ -149,55 +134,3 @@ $text-utils: (
   @include m.diamond-pill;
 }
 
-// -- Animated-background keyframes + custom property registrations -----------
-@keyframes gradient-animation {
-  0% {
-    --y-0: 80%;  --x-0: 85%;  --s-start-0: 9%;  --s-end-0: 55%;
-    --c-0: hsla(266.99999999999983, 1%, 12%, 1);
-    --c-1: hsla(335.9999999999997, 2%, 22%, 1);
-    --y-1: 24%;  --x-1: 60%;  --s-start-1: 5%;  --s-end-1: 72%;
-    --x-2: 13%;  --y-2: 82%;  --s-start-2: 5%;  --s-end-2: 52%;
-    --c-2: hsla(53.999999999999886, 0%, 0%, 0.49);
-    --y-3: 7%;   --x-3: 24%;  --s-start-3: 13%; --s-end-3: 68%;
-    --c-3: hsla(299, 4%, 36%, 1);
-  }
-  100% {
-    --y-0: 94%;  --x-0: 31%;  --s-start-0: 9%;  --s-end-0: 55%;
-    --c-0: hsla(266.99999999999943, 0%, 12%, 1);
-    --c-1: hsla(0, 4%, 19%, 1);
-    --y-1: 25%;  --x-1: 2%;   --s-start-1: 5%;  --s-end-1: 72%;
-    --x-2: 98%;  --y-2: 20%;  --s-start-2: 5%;  --s-end-2: 52%;
-    --c-2: hsla(54.000000000000036, 0%, 0%, 0.49);
-    --y-3: 92%;  --x-3: 95%;  --s-start-3: 13%; --s-end-3: 68%;
-    --c-3: hsla(298.99999999999994, 3%, 41%, 1);
-  }
-}
-
-// Registered custom properties so the gradient stops/colors tween smoothly.
-$percent-props: (
-  (--y-0, 80%), (--x-0, 85%), (--s-start-0, 9%),  (--s-end-0, 55%),
-  (--y-1, 24%), (--x-1, 60%), (--s-start-1, 5%),  (--s-end-1, 72%),
-  (--x-2, 13%), (--y-2, 82%), (--s-start-2, 5%),  (--s-end-2, 52%),
-  (--y-3, 7%),  (--x-3, 24%), (--s-start-3, 13%), (--s-end-3, 68%)
-);
-$color-props: (
-  (--c-0, hsla(266.99999999999983, 1%, 12%, 1)),
-  (--c-1, hsla(335.9999999999997, 2%, 22%, 1)),
-  (--c-2, hsla(53.999999999999886, 0%, 0%, 0.49)),
-  (--c-3, hsla(299, 4%, 36%, 1))
-);
-
-@each $name, $initial in $percent-props {
-  @property #{$name} {
-    syntax: "<percentage>";
-    inherits: false;
-    initial-value: $initial;
-  }
-}
-@each $name, $initial in $color-props {
-  @property #{$name} {
-    syntax: "<color>";
-    inherits: false;
-    initial-value: $initial;
-  }
-}


### PR DESCRIPTION
## Summary
Replace the CSS radial-gradient + `@property` animation with a dedicated `<app-background>` component that renders a WebGL1 full-screen triangle driving two GLSL layers:

- **Mist** — domain-warped value-noise fBm sampled in the diamond palette (charcoal → slate → purple → teal) with a soft vignette so cards retain contrast.
- **Lattice** — distance-field grid lines drifting slowly in time, with a second 45°-rotated grid for cross-hatch depth.

## Implementation
- Render loop runs outside NgZone so frames don't retrigger change detection.
- `prefers-reduced-motion: reduce` → one static frame instead of the loop.
- Device-pixel-ratio capped at 1.5 to save GPU work on high-DPI phones.
- ResizeObserver (with window-resize fallback).
- Graceful fallback: WebGL init failure → solid charcoal via host `:host { background: charcoal }`.
- Old CSS removed: `@keyframes gradient-animation`, the four radial-gradients on `<main>`, and the two `@each`-generated lists of `@property` declarations (~90 lines of pseudo-shader CSS gone).
- `<header>`, `[menu]`, `.container-xl`, `<footer>` pinned to `z-index: 1` so they paint above the fixed canvas at `z-index: 0`.

## Test plan
- [x] `ng build --configuration development` succeeds
- [x] `ng test --watch=false --browsers=ChromeHeadless` — 134/134 pass
- [ ] Visual spot-check at 320 / 768 / 1440 viewports
- [ ] Confirm `prefers-reduced-motion` renders a frozen frame
- [ ] Confirm WebGL-disabled browser falls back to solid charcoal

🤖 Generated with [Claude Code](https://claude.com/claude-code)