### PR TITLE
Reduced-motion: flat grey background + plain text title

### DIFF
--- a/src/app/background/background.component.scss
+++ b/src/app/background/background.component.scss
@@ -6,6 +6,10 @@
   z-index: 0;
   display: block;
   background: #050208;
+
+  @media (prefers-reduced-motion: reduce) {
+    background: t.$charcoal;
+  }
 }
 
 .vanta-host {

--- a/src/app/shared/sparkle-text.directive.ts
+++ b/src/app/shared/sparkle-text.directive.ts
@@ -70,6 +70,7 @@ export class SparkleTextDirective implements AfterViewInit, OnDestroy {
     if (!text) return;
 
     this.motion = matchMedia('(prefers-reduced-motion: reduce)');
+    if (this.motion.matches) return;
     this.motion.addEventListener('change', this.onMotion);
 
     this.canvas = document.createElement('canvas');
@@ -137,8 +138,14 @@ export class SparkleTextDirective implements AfterViewInit, OnDestroy {
 
   private syncState(): void {
     cancelAnimationFrame(this.raf);
+    if (this.motion?.matches) {
+      const host = this.hostRef.nativeElement;
+      if (this.canvas?.parentElement === host) host.removeChild(this.canvas);
+      host.style.color = this.prevColor;
+      host.style.position = this.prevPosition;
+      return;
+    }
     this.render();
-    if (this.motion?.matches) return;
     this.zone.runOutsideAngular(() => {
       const loop = () => {
         this.render();


### PR DESCRIPTION
## Summary

When the user's OS or browser has `prefers-reduced-motion: reduce` active:

### Background
- Vanta effects already didn't start (existing `syncState` logic bails out).
- **New**: host element background changes from near-black `#050208` to the site's `$charcoal` (`rgb(71,71,71)`) via a CSS media query — so the page has a visible, theme-consistent flat dark grey instead of an almost-invisible dark.

### SparkleTextDirective (title shimmer)
- **New**: if reduced-motion is active at init, the directive bails out immediately — no canvas created, no `color: transparent` set, no WebGL context. The title renders as plain CSS text in its normal lavender color.
- **New**: if reduced-motion toggles on dynamically (user changes OS setting mid-session), `syncState` now removes the canvas and restores the host's original inline styles so the text becomes visible again.

## Test plan
- [x] `ng build --configuration development`
- [x] `ng test --watch=false` — 223 / 223 pass
- [ ] Toggle OS reduced-motion on: background goes flat grey, title shows as plain lavender text
- [ ] Toggle OS reduced-motion off: background animates, title sparkles

🤖 Generated with [Claude Code](https://claude.com/claude-code)