### PR TITLE
Reactive patterns, leak fix, deferred init

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -15,17 +15,17 @@
 <button
   type="button"
   class="bg-toggle"
-  [class.is-paused]="bg.paused"
-  [attr.aria-pressed]="bg.paused"
+  [class.is-paused]="bg.paused()"
+  [attr.aria-pressed]="bg.paused()"
   [attr.aria-label]="
-    bg.paused ? 'Resume background animation' : 'Pause background animation'
+    bg.paused() ? 'Resume background animation' : 'Pause background animation'
   "
   [title]="
-    bg.paused ? 'Resume background animation' : 'Pause background animation'
+    bg.paused() ? 'Resume background animation' : 'Pause background animation'
   "
   (click)="bg.toggle()"
 >
-  @if (bg.paused) {
+  @if (bg.paused()) {
     <svg
       aria-hidden="true"
       focusable="false"
@@ -47,6 +47,6 @@
     </svg>
   }
   <span class="bg-toggle__label">{{
-    bg.paused ? "Resume animation" : "Pause animation"
+    bg.paused() ? "Resume animation" : "Pause animation"
   }}</span>
 </button>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -2,13 +2,14 @@ import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { AppComponent } from './app.component';
+import { BackgroundComponent } from './background/background.component';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 
 describe('AppComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [RouterTestingModule, TranslateModule.forRoot()],
-      declarations: [AppComponent],
+      declarations: [AppComponent, BackgroundComponent],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
     });
     const translate = TestBed.inject(TranslateService);

--- a/src/app/background/background.component.ts
+++ b/src/app/background/background.component.ts
@@ -1,9 +1,11 @@
 import {
-  AfterViewInit,
+  afterNextRender,
   Component,
+  DestroyRef,
   ElementRef,
+  inject,
   NgZone,
-  OnDestroy,
+  signal,
   ViewChild,
 } from '@angular/core';
 import * as THREE from 'three';
@@ -13,7 +15,6 @@ import FOG from 'vanta/dist/vanta.fog.min';
 
 type VantaEffect = {
   destroy: () => void;
-  setOptions?: (o: Record<string, unknown>) => void;
 };
 
 const THEME = {
@@ -30,7 +31,7 @@ const THEME = {
   styleUrl: './background.component.scss',
   standalone: false,
 })
-export class BackgroundComponent implements AfterViewInit, OnDestroy {
+export class BackgroundComponent {
   @ViewChild('mistBackHost', { static: true })
   private mistBackRef!: ElementRef<HTMLDivElement>;
 
@@ -40,34 +41,37 @@ export class BackgroundComponent implements AfterViewInit, OnDestroy {
   @ViewChild('mistFrontHost', { static: true })
   private mistFrontRef!: ElementRef<HTMLDivElement>;
 
-  paused = false;
+  readonly paused = signal(false);
 
   private mistBack: VantaEffect | null = null;
   private net: VantaEffect | null = null;
   private mistFront: VantaEffect | null = null;
   private motion?: MediaQueryList;
   private onMotion = () => this.syncState();
+  private zone = inject(NgZone);
 
-  constructor(private zone: NgZone) {}
+  constructor() {
+    const destroyRef = inject(DestroyRef);
 
-  ngAfterViewInit(): void {
-    this.motion = matchMedia('(prefers-reduced-motion: reduce)');
-    this.motion.addEventListener('change', this.onMotion);
-    this.syncState();
-  }
+    afterNextRender(() => {
+      this.motion = matchMedia('(prefers-reduced-motion: reduce)');
+      this.motion.addEventListener('change', this.onMotion);
+      this.syncState();
+    });
 
-  ngOnDestroy(): void {
-    this.teardown();
-    this.motion?.removeEventListener('change', this.onMotion);
+    destroyRef.onDestroy(() => {
+      this.teardown();
+      this.motion?.removeEventListener('change', this.onMotion);
+    });
   }
 
   toggle(): void {
-    this.paused = !this.paused;
+    this.paused.update((v) => !v);
     this.syncState();
   }
 
   private syncState(): void {
-    const shouldRun = !this.paused && !this.motion?.matches;
+    const shouldRun = !this.paused() && !this.motion?.matches;
     if (shouldRun && !this.net) {
       this.zone.runOutsideAngular(() => this.startEffects());
     } else if (!shouldRun && this.net) {

--- a/src/app/menu/menu.component.ts
+++ b/src/app/menu/menu.component.ts
@@ -1,10 +1,6 @@
-import { Component, ElementRef, QueryList, ViewChildren } from '@angular/core';
-import {
-  NavigationEnd,
-  Router,
-  RouterLink,
-  RouterLinkActive,
-} from '@angular/router';
+import { Component, DestroyRef, ElementRef, QueryList, ViewChildren, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { NavigationEnd, Router, RouterLink, RouterLinkActive } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { filter } from 'rxjs';
 import { MENU_ITEMS, MenuItem } from '../app-routing.module';
@@ -27,16 +23,18 @@ export class MenuComponent {
   @ViewChildren('navBtn', { read: ElementRef })
   navButtonRefs!: QueryList<ElementRef<HTMLButtonElement>>;
 
-  constructor(private router: Router) {
-    this.router.events
-      .pipe(filter((event) => event instanceof NavigationEnd))
+  constructor() {
+    const router = inject(Router);
+    const destroyRef = inject(DestroyRef);
+
+    router.events
+      .pipe(
+        filter((event) => event instanceof NavigationEnd),
+        takeUntilDestroyed(destroyRef),
+      )
       .subscribe(() => {
-        const mainContent = document.querySelector(
-          '#maincontent',
-        ) as HTMLElement;
-        if (mainContent) {
-          mainContent.focus();
-        }
+        const el = document.getElementById('maincontent');
+        el?.focus();
       });
   }
 }

--- a/src/app/shared/sparkle-text.directive.ts
+++ b/src/app/shared/sparkle-text.directive.ts
@@ -1,9 +1,10 @@
 import {
-  AfterViewInit,
+  afterNextRender,
+  DestroyRef,
   Directive,
   ElementRef,
+  inject,
   NgZone,
-  OnDestroy,
 } from '@angular/core';
 
 const VS = `attribute vec2 a;varying vec2 v;void main(){v=(a+1.)*.5;gl_Position=vec4(a,0.,1.);}`;
@@ -46,7 +47,7 @@ void main(){
   selector: '[sparkle]',
   standalone: false,
 })
-export class SparkleTextDirective implements AfterViewInit, OnDestroy {
+export class SparkleTextDirective {
   private canvas?: HTMLCanvasElement;
   private gl?: WebGLRenderingContext;
   private tex?: WebGLTexture;
@@ -59,12 +60,26 @@ export class SparkleTextDirective implements AfterViewInit, OnDestroy {
   private prevColor = '';
   private prevPosition = '';
 
-  constructor(
-    private hostRef: ElementRef<HTMLElement>,
-    private zone: NgZone,
-  ) {}
+  private hostRef = inject(ElementRef<HTMLElement>);
+  private zone = inject(NgZone);
 
-  ngAfterViewInit(): void {
+  constructor() {
+    const destroyRef = inject(DestroyRef);
+
+    afterNextRender(() => this.init());
+
+    destroyRef.onDestroy(() => {
+      cancelAnimationFrame(this.raf);
+      this.ro?.disconnect();
+      this.motion?.removeEventListener('change', this.onMotion);
+      const host = this.hostRef.nativeElement;
+      if (this.canvas?.parentElement === host) host.removeChild(this.canvas);
+      host.style.color = this.prevColor;
+      host.style.position = this.prevPosition;
+    });
+  }
+
+  private init(): void {
     const host = this.hostRef.nativeElement;
     const text = (host.textContent || '').trim();
     if (!text) return;
@@ -126,16 +141,6 @@ export class SparkleTextDirective implements AfterViewInit, OnDestroy {
     this.syncState();
   }
 
-  ngOnDestroy(): void {
-    cancelAnimationFrame(this.raf);
-    this.ro?.disconnect();
-    this.motion?.removeEventListener('change', this.onMotion);
-    const host = this.hostRef.nativeElement;
-    if (this.canvas?.parentElement === host) host.removeChild(this.canvas);
-    host.style.color = this.prevColor;
-    host.style.position = this.prevPosition;
-  }
-
   private syncState(): void {
     cancelAnimationFrame(this.raf);
     if (this.motion?.matches) {
@@ -184,7 +189,7 @@ export class SparkleTextDirective implements AfterViewInit, OnDestroy {
     const styles = getComputedStyle(host);
     const lines: string[] = [];
     let buf = '';
-    for (const node of Array.from(host.childNodes)) {
+    for (const node of Array.from(host.childNodes) as ChildNode[]) {
       if (node === canvas) continue;
       if (node.nodeName === 'BR') {
         if (buf.trim()) lines.push(buf.trim());


### PR DESCRIPTION
## Summary

### Leak fix
**MenuComponent** — `router.events.subscribe()` was never unsubscribed. Now piped through `takeUntilDestroyed(DestroyRef)`.

### Reactive patterns
| File | Change |
|---|---|
| `menu.component.ts` | `inject()` for Router/DestroyRef, `takeUntilDestroyed` |
| `background.component.ts` | `afterNextRender` + `DestroyRef.onDestroy`, `signal()` for paused, `inject()` for NgZone |
| `sparkle-text.directive.ts` | `afterNextRender` + `DestroyRef.onDestroy`, `inject()` for ElementRef/NgZone |
| `app.component.html` | `bg.paused` → `bg.paused()` (signal read) |

### Reduced jank
`afterNextRender` defers vanta + WebGL init until **after the first frame paints** — browser renders the static HTML shell first, effects bootstrap in the background.

## Test plan
- [x] `ng build --configuration development`
- [x] `ng test --watch=false` — 223 / 223 pass
- [x] Vanta background renders correctly after fix for inject(NgZone) outside injection context

🤖 Generated with [Claude Code](https://claude.com/claude-code)