### PR TITLE
SEO: meta tags, structured data, sitemap, per-route titles

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -28,7 +28,6 @@
             "tsConfig": "tsconfig.app.json",
             "assets": [
               "src/favicon.ico",
-              "src/favicon.svg",
               "src/assets",
               "src/robots.txt",
               "src/sitemap.xml"

--- a/angular.json
+++ b/angular.json
@@ -26,7 +26,12 @@
               "src/polyfills.ts"
             ],
             "tsConfig": "tsconfig.app.json",
-            "assets": ["src/favicon.ico", "src/assets"],
+            "assets": [
+              "src/favicon.ico",
+              "src/assets",
+              "src/robots.txt",
+              "src/sitemap.xml"
+            ],
             "styles": [
               "src/styles.scss"
             ],

--- a/angular.json
+++ b/angular.json
@@ -28,6 +28,7 @@
             "tsConfig": "tsconfig.app.json",
             "assets": [
               "src/favicon.ico",
+              "src/favicon.svg",
               "src/assets",
               "src/robots.txt",
               "src/sitemap.xml"

--- a/server.js
+++ b/server.js
@@ -20,7 +20,7 @@ function getRoot(request, response) {
   response.sendFile(path.resolve(distDir + "index.html"));
 }
 
-app.get("*", getRoot);
+app.get("/{*path}", getRoot);
 
 app.listen(port, () =>
   console.log(`Example app listening on port 

--- a/server.js
+++ b/server.js
@@ -20,7 +20,7 @@ function getRoot(request, response) {
   response.sendFile(path.resolve(distDir + "index.html"));
 }
 
-app.get("/", getRoot);
+app.get("*", getRoot);
 
 app.listen(port, () =>
   console.log(`Example app listening on port 

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -13,6 +13,7 @@ export interface MenuItem {
   readonly order: number;
   readonly disabled: boolean;
   readonly component: Type<unknown>;
+  readonly title: string;
 }
 
 export const MENU_ITEMS: readonly MenuItem[] = [
@@ -22,6 +23,7 @@ export const MENU_ITEMS: readonly MenuItem[] = [
     order: 1,
     disabled: false,
     component: HomeComponent,
+    title: 'Usi Diamond — Introduction',
   },
   {
     labelKey: 'menu.projects',
@@ -29,6 +31,7 @@ export const MENU_ITEMS: readonly MenuItem[] = [
     order: 2,
     disabled: false,
     component: ProjectsComponent,
+    title: 'Usi Diamond — Projects',
   },
   {
     labelKey: 'menu.education',
@@ -36,6 +39,7 @@ export const MENU_ITEMS: readonly MenuItem[] = [
     order: 3,
     disabled: false,
     component: EducationComponent,
+    title: 'Usi Diamond — Education & Training',
   },
   {
     labelKey: 'menu.volunteering',
@@ -43,6 +47,7 @@ export const MENU_ITEMS: readonly MenuItem[] = [
     order: 4,
     disabled: false,
     component: VolunteeringComponent,
+    title: 'Usi Diamond — Volunteering',
   },
   {
     labelKey: 'menu.reading',
@@ -50,6 +55,7 @@ export const MENU_ITEMS: readonly MenuItem[] = [
     order: 5,
     disabled: true,
     component: ReadingComponent,
+    title: 'Usi Diamond — Reading',
   },
   {
     labelKey: 'menu.contact',
@@ -57,12 +63,14 @@ export const MENU_ITEMS: readonly MenuItem[] = [
     order: 6,
     disabled: false,
     component: ContactComponent,
+    title: 'Usi Diamond — Contact',
   },
 ];
 
 const activeRoutes: Routes = MENU_ITEMS.filter((m) => !m.disabled).map((m) => ({
   path: m.route,
   component: m.component,
+  title: m.title,
 }));
 
 const disabledRedirects: Routes = MENU_ITEMS.filter((m) => m.disabled).map(

--- a/src/favicon.svg
+++ b/src/favicon.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <text y="0.9em" font-size="80" text-anchor="middle" x="50">🐉</text>
-</svg>

--- a/src/favicon.svg
+++ b/src/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text y="0.9em" font-size="80" text-anchor="middle" x="50">🐉</text>
+</svg>

--- a/src/index.html
+++ b/src/index.html
@@ -77,7 +77,7 @@
       }
     </script>
 
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🐉</text></svg>" />
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22 style=%22filter:grayscale(1)%22><text y=%22.9em%22 font-size=%2290%22>🐉</text></svg>" />
   </head>
   <body>
     <main app-root></main>

--- a/src/index.html
+++ b/src/index.html
@@ -2,32 +2,91 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="title" content="Usi Diamond" />
-    <meta name="description" content="Usi Diamond's Website" />
+    <title>Usi Diamond — Full-Stack Engineer & Performing Artist</title>
+    <meta
+      name="description"
+      content="Personal site of Usi'ia Lior Diamond: full-stack software engineer, opera singer, and community advocate based in Baltimore, MD."
+    />
+    <meta name="author" content="Usi Diamond" />
     <meta
       name="keywords"
-      content="personal-website, full-stack, engineer, developer, enby, nonbinary, queer"
+      content="Usi Diamond, full-stack engineer, Angular developer, software engineer, opera singer, nonbinary, queer developer, Baltimore"
     />
-    <meta name="robots" content="index, nofollow" />
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <meta name="language" content="English" />
-    <meta name="revisit-after" content="30 days" />
-    <meta name="author" content="Usi Diamond" />
-    <meta name="generator" content="Angular 19" />
-    <meta name="dcterms.rightsHolder" content="CC0 1.0 Universal" />
-    <meta property="url" content="https://usidiamond.github.io" />
-    <meta property="og:locale" content="es_ES" />
-    <meta property="og:type" content="website" />
     <meta
       name="robots"
-      content="follow, index, max-snippet:-1, max-video-preview:-1, max-image-preview:large"
+      content="index, follow, max-snippet:-1, max-video-preview:-1, max-image-preview:large"
     />
+    <link rel="canonical" href="https://usidiamond.dev/" />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta
+      property="og:title"
+      content="Usi Diamond — Full-Stack Engineer & Performing Artist"
+    />
+    <meta
+      property="og:description"
+      content="Personal site of Usi'ia Lior Diamond: full-stack software engineer, opera singer, and community advocate based in Baltimore, MD."
+    />
+    <meta property="og:url" content="https://usidiamond.dev/" />
+    <meta property="og:site_name" content="Usi Diamond" />
+    <meta property="og:locale" content="en_US" />
+
+    <!-- Twitter / X -->
+    <meta name="twitter:card" content="summary" />
+    <meta
+      name="twitter:title"
+      content="Usi Diamond — Full-Stack Engineer & Performing Artist"
+    />
+    <meta
+      name="twitter:description"
+      content="Full-stack software engineer, opera singer, and community advocate."
+    />
+
+    <!-- Performance hints -->
+    <link
+      rel="preload"
+      href="assets/MoreSugar-Thin.ttf"
+      as="font"
+      type="font/ttf"
+      crossorigin
+    />
+
+    <!-- Structured data (JSON-LD) -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Person",
+        "name": "Usi'ia Lior Diamond",
+        "alternateName": "Usi Diamond",
+        "url": "https://usidiamond.dev",
+        "sameAs": [
+          "https://www.linkedin.com/in/usidiamond/",
+          "https://github.com/usidiamond/"
+        ],
+        "jobTitle": "Full-Stack Software Engineer",
+        "knowsAbout": [
+          "Angular",
+          "Spring",
+          "OpenShift",
+          "Java",
+          "JavaScript",
+          "TypeScript"
+        ]
+      }
+    </script>
+
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
-    <title>Usi Diamond</title>
   </head>
   <body>
     <main app-root></main>
+    <noscript>
+      <h1>Usi'ia Lior Diamond</h1>
+      <p>
+        Full-stack software engineer, opera singer, and community advocate.
+        Enable JavaScript to view the full interactive site.
+      </p>
+    </noscript>
   </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -77,6 +77,7 @@
       }
     </script>
 
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
   </head>
   <body>

--- a/src/index.html
+++ b/src/index.html
@@ -77,8 +77,7 @@
       }
     </script>
 
-    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
-    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🐉</text></svg>" />
   </head>
   <body>
     <main app-root></main>

--- a/src/robots.txt
+++ b/src/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://usidiamond.dev/sitemap.xml

--- a/src/sitemap.xml
+++ b/src/sitemap.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://usidiamond.dev/#/home</loc>
+    <priority>1.0</priority>
+    <changefreq>monthly</changefreq>
+  </url>
+  <url>
+    <loc>https://usidiamond.dev/#/projects</loc>
+    <priority>0.8</priority>
+    <changefreq>monthly</changefreq>
+  </url>
+  <url>
+    <loc>https://usidiamond.dev/#/education</loc>
+    <priority>0.7</priority>
+    <changefreq>yearly</changefreq>
+  </url>
+  <url>
+    <loc>https://usidiamond.dev/#/volunteering</loc>
+    <priority>0.7</priority>
+    <changefreq>yearly</changefreq>
+  </url>
+  <url>
+    <loc>https://usidiamond.dev/#/contact</loc>
+    <priority>0.6</priority>
+    <changefreq>yearly</changefreq>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary

### Meta tags (index.html)
- Descriptive `<title>` and `<meta name="description">` with keywords
- Fix `robots` from `nofollow` → `follow`; remove duplicate tag
- Fix `og:locale` from `es_ES` → `en_US`
- Full Open Graph suite (`og:title`, `og:description`, `og:url`, `og:site_name`)
- Twitter/X card (`twitter:card`, `twitter:title`, `twitter:description`)
- `<link rel="canonical">` pointing to https://usidiamond.dev/

### Structured data
- JSON-LD `Person` schema with name, jobTitle, sameAs (LinkedIn, GitHub), knowsAbout (Angular, Spring, etc.) — enables Google knowledge panel

### Performance
- `<link rel="preload">` for the MoreSugar font to reduce FOIT
- `<noscript>` fallback so crawlers without JS get indexable content

### New assets
- `robots.txt` — allows all, points to sitemap
- `sitemap.xml` — all five active routes with priority/changefreq

### Per-route titles
- `title` field on each `MenuItem` passed through to Angular route config → browser tab updates per page via Angular's built-in `TitleStrategy`

### Server
- Express catch-all `app.get("*", ...)` so deep links serve the SPA shell

## Note
The site uses `HashLocationStrategy` — hash-fragment URLs are partially opaque to crawlers. A follow-up migration to `PathLocationStrategy` would unlock full crawlability but requires GitHub Pages 404.html or a hosting change.

## Test plan
- [x] `ng build` — robots.txt + sitemap.xml in build output
- [x] `ng test --watch=false` — 223 / 223 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)