### PR TITLE
ci: beautify PR test reports for unit and integration tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -38,7 +38,7 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Post unit test summary as PR comment
-        if: always() && github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request' && hashFiles('coverage/usidiamond/pr-comment.md') != ''
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: unit-tests

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,10 +1,9 @@
-# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+name: Unit Tests & Coverage
 
-name: Code Coverage
 permissions:
   checks: write
   pull-requests: write
+  contents: read
 
 on:
   push:
@@ -13,23 +12,42 @@ on:
     branches: ["main", "release/*"]
 
 jobs:
-  build_and_test:
+  test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [24.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
-      - name: npm install and coverage
-        run: |
-          npm install
-          npm run-script coverage
-      - name: Publish Test Results
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24.x"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests with coverage
+        run: npm run coverage
+
+      - name: Generate unit test summary
+        if: always()
+        run: node generate-unit-summary.js
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Post unit test summary as PR comment
+        if: always() && github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: unit-tests
+          path: coverage/usidiamond/pr-comment.md
+
+      - name: Publish test results check
         uses: EnricoMi/publish-unit-test-result-action@v2.18.0
         if: always()
         with:
-          files: |
-            coverage/usidiamond/**/test-results.xml
+          files: coverage/usidiamond/**/test-results.xml
+          check_name: Unit Tests
+          comment_title: Unit Tests

--- a/generate-summary.js
+++ b/generate-summary.js
@@ -35,7 +35,10 @@ function truncate(str, max = 180) {
 }
 
 function esc(str) {
-  return (str || "").replace(/\|/g, "\\|").replace(/`/g, "'");
+  return (str || "")
+    .replace(/\\/g, "\\\\")
+    .replace(/\|/g, "\\|")
+    .replace(/`/g, "'");
 }
 
 // ── load report ──────────────────────────────────────────────────────────────

--- a/generate-summary.js
+++ b/generate-summary.js
@@ -1,13 +1,15 @@
 #!/usr/bin/env node
 /**
- * Generates a GitHub Actions job summary from the Cucumber JSON report.
- * Writes a markdown table of pass/fail results per scenario, with a link
- * to the uploaded artifact that contains the HTML report with embedded screenshots.
+ * Generates a GitHub Actions job summary and sticky PR comment from the
+ * Cucumber JSON report produced by Nightwatch + Cucumber.
  *
- * Usage: node e2e/generate-summary.js
- * Env:   GITHUB_STEP_SUMMARY - path to the GitHub Actions summary file
- *        ARTIFACT_URL        - direct URL to the uploaded test report artifact
+ * Env:
+ *   GITHUB_STEP_SUMMARY  – path provided automatically by GitHub Actions
+ *   ARTIFACT_URL         – direct URL to the uploaded artifact (optional)
+ *   RUN_URL              – link back to the Actions run (optional)
  */
+
+"use strict";
 
 const fs = require("fs");
 const path = require("path");
@@ -17,6 +19,26 @@ const SUMMARY_FILE = process.env.GITHUB_STEP_SUMMARY;
 const PR_COMMENT_FILE = "integration-tests-report/pr-comment.md";
 const ARTIFACT_URL = process.env.ARTIFACT_URL || "";
 const RUN_URL = process.env.RUN_URL || "";
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function ns2s(ns) {
+  if (!ns || ns === 0) return "";
+  return (ns / 1e9).toFixed(2) + "s";
+}
+
+/** Truncate a string and replace newlines for display in a table cell. */
+function truncate(str, max = 180) {
+  if (!str) return "";
+  const flat = str.replace(/\r?\n|\r/g, " ").trim();
+  return flat.length > max ? flat.slice(0, max) + "…" : flat;
+}
+
+function esc(str) {
+  return (str || "").replace(/\|/g, "\\|").replace(/`/g, "'");
+}
+
+// ── load report ──────────────────────────────────────────────────────────────
 
 if (!fs.existsSync(REPORT_PATH)) {
   console.log("No cucumber report found at", REPORT_PATH);
@@ -31,100 +53,137 @@ try {
   process.exit(1);
 }
 
-const lines = [];
-lines.push("## Integration Test Results\n");
+// ── aggregate counts ──────────────────────────────────────────────────────────
 
 let totalPassed = 0;
 let totalFailed = 0;
 let totalSkipped = 0;
 
 for (const feature of features) {
-  const featureFailed = feature.elements.some((scenario) =>
-    scenario.steps.some(
-      (step) => step.result && step.result.status === "failed"
-    )
-  );
-  const featureIcon = featureFailed ? "❌" : "✅";
-
-  lines.push(`### ${featureIcon} ${feature.name}\n`);
-  lines.push("| Scenario | Status | Screenshot |");
-  lines.push("|----------|--------|------------|");
-
   for (const scenario of feature.elements) {
     const failed = scenario.steps.some(
-      (step) => step.result && step.result.status === "failed"
+      (s) => s.result && s.result.status === "failed"
     );
     const skipped =
       !failed &&
-      scenario.steps.some(
-        (step) => step.result && step.result.status === "skipped"
-      );
+      scenario.steps.some((s) => s.result && s.result.status === "skipped");
+    if (failed) totalFailed++;
+    else if (skipped) totalSkipped++;
+    else totalPassed++;
+  }
+}
 
-    let statusIcon, statusLabel;
-    if (failed) {
-      statusIcon = "❌";
-      statusLabel = "Failed";
-      totalFailed++;
+const totalScenarios = totalPassed + totalFailed + totalSkipped;
+const allPassed = totalFailed === 0;
+
+// ── build markdown ────────────────────────────────────────────────────────────
+
+const out = [];
+
+// ── banner ──
+const bannerIcon = allPassed ? "✅" : "❌";
+const bannerTitle = allPassed
+  ? `All ${totalScenarios} scenarios passed`
+  : `${totalFailed} of ${totalScenarios} scenarios failed`;
+
+out.push(`## ${bannerIcon} Integration Tests — ${bannerTitle}\n`);
+out.push(
+  `> **${totalPassed}** passed &nbsp;·&nbsp; **${totalFailed}** failed &nbsp;·&nbsp; **${totalSkipped}** skipped &nbsp;·&nbsp; **${features.length}** feature${features.length === 1 ? "" : "s"}\n`
+);
+out.push("");
+
+// ── per-feature details ──
+for (const feature of features) {
+  const featureFailed = feature.elements.some((sc) =>
+    sc.steps.some((s) => s.result && s.result.status === "failed")
+  );
+  const featureIcon = featureFailed ? "❌" : "✅";
+  const passed = feature.elements.filter(
+    (sc) => !sc.steps.some((s) => s.result && s.result.status === "failed")
+  ).length;
+  const failed = feature.elements.length - passed;
+  const subtitle = featureFailed
+    ? ` — ${failed} failed`
+    : ` — ${passed} passed`;
+
+  // Failing features are open by default; passing ones are collapsed.
+  const openAttr = featureFailed ? " open" : "";
+  out.push(
+    `<details${openAttr}><summary>${featureIcon} <strong>${esc(feature.name)}</strong>${subtitle} (${feature.elements.length} scenario${feature.elements.length === 1 ? "" : "s"})</summary>\n`
+  );
+  out.push("");
+  out.push("| Scenario | Status | Duration |");
+  out.push("|----------|--------|----------|");
+
+  for (const scenario of feature.elements) {
+    const failedStep = scenario.steps.find(
+      (s) => s.result && s.result.status === "failed"
+    );
+    const skipped =
+      !failedStep &&
+      scenario.steps.some((s) => s.result && s.result.status === "skipped");
+
+    let statusCell;
+    if (failedStep) {
+      const errMsg = truncate(failedStep.result.error_message);
+      statusCell = errMsg
+        ? `❌ Failed<br><sub><code>${esc(errMsg)}</code></sub>`
+        : "❌ Failed";
     } else if (skipped) {
-      statusIcon = "⏭️";
-      statusLabel = "Skipped";
-      totalSkipped++;
+      statusCell = "⏭️ Skipped";
     } else {
-      statusIcon = "✅";
-      statusLabel = "Passed";
-      totalPassed++;
+      statusCell = "✅ Passed";
     }
 
-    // Check if a screenshot was attached to any step
-    const hasScreenshot = scenario.steps.some(
-      (step) =>
-        step.embeddings &&
-        step.embeddings.some((e) => e.mime_type === "image/png")
+    // Total duration = sum of all step durations
+    const durationNs = scenario.steps.reduce(
+      (acc, s) => acc + (s.result && s.result.duration ? s.result.duration : 0),
+      0
     );
-    const screenshotNote = hasScreenshot ? "📸 In report" : "—";
+    const durationCell = ns2s(durationNs) || "—";
 
-    lines.push(
-      `| ${scenario.name} | ${statusIcon} ${statusLabel} | ${screenshotNote} |`
+    out.push(
+      `| ${esc(scenario.name)} | ${statusCell} | ${durationCell} |`
     );
   }
 
-  lines.push("");
+  out.push("");
+  out.push("</details>\n");
 }
 
-lines.push("\n---\n");
-lines.push(
-  `**Summary:** ✅ ${totalPassed} passed &nbsp; ❌ ${totalFailed} failed &nbsp; ⏭️ ${totalSkipped} skipped\n`
-);
+// ── footer ──
+out.push("---\n");
 
 if (ARTIFACT_URL) {
-  lines.push(
-    `> 📥 [Download the integration-test-report artifact](${ARTIFACT_URL}) to view the HTML report with screenshots embedded for each scenario.`
+  out.push(
+    `📥 [Download HTML report with screenshots](${ARTIFACT_URL})`
   );
 } else {
-  lines.push(
-    `> 📥 Download the \`integration-test-report\` artifact from this workflow run to view the HTML report with screenshots embedded for each scenario.`
+  out.push(
+    `📥 Download the \`integration-test-report\` artifact from this run for the full HTML report with screenshots.`
   );
 }
 
 if (RUN_URL) {
-  lines.push(`\n[View full workflow run ↗](${RUN_URL})`);
+  out.push(`\n[View workflow run ↗](${RUN_URL})`);
 }
 
-const summary = lines.join("\n");
+const markdown = out.join("\n");
+
+// ── write outputs ─────────────────────────────────────────────────────────────
 
 if (SUMMARY_FILE) {
-  fs.appendFileSync(SUMMARY_FILE, summary + "\n");
+  fs.appendFileSync(SUMMARY_FILE, markdown + "\n");
   console.log("Summary written to GITHUB_STEP_SUMMARY");
 } else {
   console.log("GITHUB_STEP_SUMMARY not set — preview:");
-  console.log(summary);
+  console.log(markdown);
 }
 
-// Always write a file copy so the workflow can post it as a PR comment.
 try {
   fs.mkdirSync(path.dirname(PR_COMMENT_FILE), { recursive: true });
-  fs.writeFileSync(PR_COMMENT_FILE, summary + "\n");
-  console.log(`PR comment body written to ${PR_COMMENT_FILE}`);
+  fs.writeFileSync(PR_COMMENT_FILE, markdown + "\n");
+  console.log("PR comment written to", PR_COMMENT_FILE);
 } catch (e) {
   console.error("Failed to write PR comment file:", e.message);
 }

--- a/generate-unit-summary.js
+++ b/generate-unit-summary.js
@@ -13,7 +13,33 @@
 const fs = require("fs");
 const path = require("path");
 
-const JUNIT_PATH = "coverage/usidiamond/test-results.xml";
+const JUNIT_DIR  = "coverage/usidiamond";
+const JUNIT_FILE = "test-results.xml";
+
+/** Find the JUnit XML by exact path first, then by recursive search. */
+function findJUnit() {
+  const exact = path.join(JUNIT_DIR, JUNIT_FILE);
+  if (fs.existsSync(exact)) return exact;
+  // karma-junit-reporter may place the file inside a browser-named subdir.
+  if (!fs.existsSync(JUNIT_DIR)) return null;
+  const found = walkFind(JUNIT_DIR, JUNIT_FILE);
+  return found || null;
+}
+
+function walkFind(dir, name) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const hit = walkFind(full, name);
+      if (hit) return hit;
+    } else if (entry.name === name) {
+      return full;
+    }
+  }
+  return null;
+}
+
+const JUNIT_PATH = findJUnit();
 const COVERAGE_PATH = "coverage/usidiamond/coverage-summary.json";
 const SUMMARY_FILE = process.env.GITHUB_STEP_SUMMARY;
 const PR_COMMENT_FILE = "coverage/usidiamond/pr-comment.md";

--- a/generate-unit-summary.js
+++ b/generate-unit-summary.js
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+/**
+ * Generates a GitHub Actions job summary and sticky PR comment from
+ * the Karma JUnit XML report and Istanbul coverage-summary.json.
+ *
+ * Env:
+ *   GITHUB_STEP_SUMMARY  – path provided automatically by GitHub Actions
+ *   RUN_URL              – link back to the Actions run (optional)
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const JUNIT_PATH = "coverage/usidiamond/test-results.xml";
+const COVERAGE_PATH = "coverage/usidiamond/coverage-summary.json";
+const SUMMARY_FILE = process.env.GITHUB_STEP_SUMMARY;
+const PR_COMMENT_FILE = "coverage/usidiamond/pr-comment.md";
+const RUN_URL = process.env.RUN_URL || "";
+
+// ── parse JUnit XML (no external deps) ───────────────────────────────────────
+
+function parseJUnit(xml) {
+  // Sum attributes across all <testsuite> elements (Karma emits one per suite)
+  let tests = 0, failures = 0, errors = 0, skipped = 0;
+
+  for (const m of xml.matchAll(/<testsuite\b([^>]*)>/g)) {
+    const attrs = m[1];
+    tests    += parseInt(attrs.match(/\btests="(\d+)"/)?.[1]    || "0", 10);
+    failures += parseInt(attrs.match(/\bfailures="(\d+)"/)?.[1] || "0", 10);
+    errors   += parseInt(attrs.match(/\berrors="(\d+)"/)?.[1]   || "0", 10);
+    skipped  += parseInt(attrs.match(/\bskipped="(\d+)"/)?.[1]  || "0", 10);
+  }
+
+  // Collect failing test cases
+  const failedTests = [];
+  for (const m of xml.matchAll(
+    /<testcase\b([^>]*)>([\s\S]*?)<\/testcase>/g
+  )) {
+    const attrs = m[1];
+    const body  = m[2];
+    if (!body.includes("<failure") && !body.includes("<error")) continue;
+
+    const name      = attrs.match(/\bname="([^"]*)"/)?.[1]      || "(unknown)";
+    const classname = attrs.match(/\bclassname="([^"]*)"/)?.[1] || "";
+
+    const msgMatch  = body.match(/<(?:failure|error)[^>]*message="([^"]*)"/);
+    const textMatch = body.match(/<(?:failure|error)[^>]*>([\s\S]*?)<\/(?:failure|error)>/);
+    const message   = msgMatch?.[1] || textMatch?.[1]?.trim() || "";
+
+    failedTests.push({ name, classname, message });
+  }
+
+  return { tests, failures, errors, skipped, failedTests };
+}
+
+// ── parse coverage summary ────────────────────────────────────────────────────
+
+function pctIcon(pct) {
+  if (pct >= 80) return "🟢";
+  if (pct >= 60) return "🟡";
+  return "🔴";
+}
+
+function fmtPct(n) {
+  return Number(n).toFixed(1) + "%";
+}
+
+// ── load inputs ───────────────────────────────────────────────────────────────
+
+if (!fs.existsSync(JUNIT_PATH)) {
+  console.log("No JUnit report found at", JUNIT_PATH);
+  process.exit(0);
+}
+
+const xml = fs.readFileSync(JUNIT_PATH, "utf8");
+const { tests, failures, errors, skipped, failedTests } = parseJUnit(xml);
+const totalFailed = failures + errors;
+const passed = tests - totalFailed - skipped;
+const allPassed = totalFailed === 0;
+
+let coverage = null;
+if (fs.existsSync(COVERAGE_PATH)) {
+  try {
+    coverage = JSON.parse(fs.readFileSync(COVERAGE_PATH, "utf8")).total;
+  } catch {
+    // coverage numbers are optional — proceed without them
+  }
+}
+
+// ── build markdown ────────────────────────────────────────────────────────────
+
+const out = [];
+
+// ── banner ──
+const bannerIcon = allPassed ? "✅" : "❌";
+const bannerTitle = allPassed
+  ? `All ${tests} unit tests passed`
+  : `${totalFailed} of ${tests} unit tests failed`;
+
+out.push(`## ${bannerIcon} Unit Tests — ${bannerTitle}\n`);
+out.push(
+  `> **${passed}** passed &nbsp;·&nbsp; **${totalFailed}** failed &nbsp;·&nbsp; **${skipped}** skipped\n`
+);
+
+// ── coverage table ──
+if (coverage) {
+  out.push("### Coverage\n");
+  out.push("| Metric | | % | Covered / Total |");
+  out.push("|--------|--|---|-----------------|");
+  for (const [label, key] of [
+    ["Statements", "statements"],
+    ["Branches",   "branches"],
+    ["Functions",  "functions"],
+    ["Lines",      "lines"],
+  ]) {
+    const m = coverage[key];
+    if (!m) continue;
+    out.push(
+      `| ${label} | ${pctIcon(m.pct)} | **${fmtPct(m.pct)}** | ${m.covered} / ${m.total} |`
+    );
+  }
+  out.push("");
+}
+
+// ── failure details ──
+if (failedTests.length > 0) {
+  out.push("<details open><summary>❌ Failed tests</summary>\n");
+  out.push("| Test | Error |");
+  out.push("|------|-------|");
+  for (const t of failedTests) {
+    const label = t.classname ? `${t.classname}` : t.name;
+    const msg = (t.message || "")
+      .replace(/\r?\n/g, " ")
+      .replace(/\|/g, "\\|")
+      .slice(0, 200);
+    out.push(`| \`${label}\` | ${msg || "—"} |`);
+  }
+  out.push("\n</details>\n");
+}
+
+// ── footer ──
+out.push("---\n");
+
+if (RUN_URL) {
+  out.push(`[View workflow run ↗](${RUN_URL})`);
+}
+
+const markdown = out.join("\n");
+
+// ── write outputs ─────────────────────────────────────────────────────────────
+
+if (SUMMARY_FILE) {
+  fs.appendFileSync(SUMMARY_FILE, markdown + "\n");
+  console.log("Summary written to GITHUB_STEP_SUMMARY");
+} else {
+  console.log("GITHUB_STEP_SUMMARY not set — preview:");
+  console.log(markdown);
+}
+
+try {
+  fs.mkdirSync(path.dirname(PR_COMMENT_FILE), { recursive: true });
+  fs.writeFileSync(PR_COMMENT_FILE, markdown + "\n");
+  console.log("PR comment written to", PR_COMMENT_FILE);
+} catch (e) {
+  console.error("Failed to write PR comment file:", e.message);
+}

--- a/generate-unit-summary.js
+++ b/generate-unit-summary.js
@@ -133,6 +133,7 @@ if (failedTests.length > 0) {
     const label = t.classname ? `${t.classname}` : t.name;
     const msg = (t.message || "")
       .replace(/\r?\n/g, " ")
+      .replace(/\\/g, "\\\\")
       .replace(/\|/g, "\\|")
       .slice(0, 200);
     out.push(`| \`${label}\` | ${msg || "—"} |`);

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -17,6 +17,14 @@ module.exports = function (config) {
       outputDir: require("path").join(__dirname, "./coverage/usidiamond/"),
       outputFile: "test-results.xml",
     },
+    coverageReporter: {
+      dir: require("path").join(__dirname, "./coverage/usidiamond/"),
+      reporters: [
+        { type: "html", subdir: "html" },
+        { type: "lcovonly", subdir: ".", file: "lcov.info" },
+        { type: "json-summary", subdir: ".", file: "coverage-summary.json" },
+      ],
+    },
     reporters: ["progress", "junit", "coverage"],
     port: 9876,
     colors: true,

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -16,6 +16,7 @@ module.exports = function (config) {
     junitReporter: {
       outputDir: require("path").join(__dirname, "./coverage/usidiamond/"),
       outputFile: "test-results.xml",
+      useBrowserName: false,
     },
     coverageReporter: {
       dir: require("path").join(__dirname, "./coverage/usidiamond/"),


### PR DESCRIPTION
## Summary
- **New `generate-unit-summary.js`**: parses the Karma JUnit XML + Istanbul `coverage-summary.json` and produces a styled markdown summary — pass/fail banner, coverage table with 🟢/🟡/🔴 thresholds, and a collapsible failure-details section
- **Improved `generate-summary.js`** (integration tests): adds an overall status banner, wraps each feature in a `<details>` block (collapsed when passing, open when failing), shows the failing step's error message inline, and shows per-scenario duration
- **`coverage.yml`** renamed to "Unit Tests & Coverage", adds the new script call, posts a sticky PR comment via `marocchino/sticky-pull-request-comment`, and properly caches npm
- **`karma.conf.js`**: adds `json-summary` coverage reporter so coverage numbers are available to the script

## Test plan
- [x] Trigger the workflow on a PR and verify both sticky comments appear
- [x] Introduce a failing unit test and confirm the failure table populates
- [ ] Introduce a failing e2e scenario and confirm its feature block is open with the error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)