### PR TITLE
fix: update Baltimore Playwrights Festival date to 2010 · 3 mos

### DIFF
--- a/src/app/volunteering/volunteering.component.html
+++ b/src/app/volunteering/volunteering.component.html
@@ -253,9 +253,7 @@
       <p class="volunteering-org" tabindex="0">
         Baltimore Playwrights Festival
       </p>
-      <p class="volunteering-date" tabindex="0">
-        2010 – Present · 16 yrs 4 mos
-      </p>
+      <p class="volunteering-date" tabindex="0">2010 · 3 mos</p>
       <p tabindex="0">
         <a
           href="https://www.broadwayworld.com/baltimore/article/Spotlighters-Theatre-Baltimore-Playwrights-Festival-Present-HAMMARSKJOLD-812-20100812"


### PR DESCRIPTION
## Summary
- Changes the Baltimore Playwrights Festival volunteering date from `2010 – Present · 16 yrs 4 mos` to `2010 · 3 mos`

## Test plan
- [ ] Verify the volunteering page displays `2010 · 3 mos` for the Baltimore Playwrights Festival entry
- [ ] Run existing unit tests: `ng test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)