### PR TITLE
fix: keep footer at viewport bottom on short pages

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -146,6 +146,8 @@ a:focus-visible {
 main {
   top: 0;
   position: absolute;
+  display: flex;
+  flex-direction: column;
   width: 100%;
   max-width: 100%;
   min-height: 100%;
@@ -161,6 +163,9 @@ header,
 footer {
   position: relative;
   z-index: 1;
+}
+.container-xl {
+  flex: 1;
 }
 [menu] {
   position: relative;


### PR DESCRIPTION
## Summary
- Adds `display: flex; flex-direction: column` to the `main` element so all direct children participate in a flex column layout
- Adds `flex: 1` to `.container-xl` (the router-outlet wrapper) so it grows to fill available space, naturally pushing the footer to the bottom
- `app-background` is `position: fixed` so it doesn't interfere with flex layout
- No change to footer behavior when content is long enough to scroll — the footer remains in normal document flow

## Test plan
- [x] Visit a short-content page (e.g. home/about) — footer should sit at the bottom of the viewport with no gap below it
- [x] Visit a long-content page — footer should appear below content as normal, not fixed/sticky
- [x] Resize the browser window to verify the footer repositions correctly at all breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)