### PR TITLE
refactor: remove express-rate-limit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@ngx-translate/http-loader": "^17.0.0",
         "bootstrap": "^5.3.8",
         "express": "^5.2.1",
-        "express-rate-limit": "^8.2.2",
         "rxjs": "^7.8.2",
         "three": "^0.183.2",
         "vanta": "^0.5.24",
@@ -13935,24 +13934,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "10.1.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/express-rate-limit"
-      },
-      "peerDependencies": {
-        "express": ">= 4.11"
-      }
-    },
     "node_modules/express/node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -16153,6 +16134,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
       "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@ngx-translate/http-loader": "^17.0.0",
     "bootstrap": "^5.3.8",
     "express": "^5.2.1",
-    "express-rate-limit": "^8.2.2",
     "rxjs": "^7.8.2",
     "three": "^0.183.2",
     "vanta": "^0.5.24",

--- a/server.js
+++ b/server.js
@@ -5,13 +5,6 @@ const { spawn } = require('child_process');
 const app = express();
 const port = 8080;
 
-var RateLimit = require('express-rate-limit');
-var limiter = RateLimit({
-  windowMs: 1 * 60 * 1000,
-  max: 500,
-});
-app.use(limiter);
-
 var distDir = __dirname + '/public/usidiamond.github.io/browser/';
 app.use(express.static(distDir));
 


### PR DESCRIPTION
## Summary
- Removes `express-rate-limit` from `server.js` and `package.json`
- This is a static file server with no user-submitted data or API endpoints; rate limiting adds no meaningful protection here

## Test plan
- [ ] `npm start` still serves the app on port 8080
- [ ] No `express-rate-limit` references remain in source

🤖 Generated with [Claude Code](https://claude.com/claude-code)