### PR TITLE
harden: production-ready nginx + Docker (OWASP)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,17 @@ COPY ./ ./
 RUN npm run build
 
 FROM nginx:stable-alpine
-# Patch any OS-level CVEs in the base image
-RUN apk upgrade --no-cache
-# Remove the default server config included by the upstream image
-RUN rm -f /etc/nginx/conf.d/default.conf
+# Patch OS-level CVEs in the base image before doing anything else
+RUN apk upgrade --no-cache \
+ && rm -f /etc/nginx/conf.d/default.conf
 COPY nginx.conf /etc/nginx/nginx.conf
-COPY --from=build /opt/usidiamond.github.io/public/usidiamond.github.io/browser /usr/share/nginx/html/browser
-RUN chown -R nginx:nginx /usr/share/nginx/html/browser
+# --chown avoids a separate RUN layer for ownership change
+COPY --from=build --chown=nginx:nginx \
+    /opt/usidiamond.github.io/public/usidiamond.github.io/browser \
+    /usr/share/nginx/html/browser
 USER nginx
 EXPOSE 8080
+# Container-level health check (also present in docker-compose for orchestrators
+# that don't read compose files, e.g. plain docker run / Kubernetes)
+HEALTHCHECK --interval=10s --timeout=5s --retries=3 --start-period=15s \
+    CMD curl -fs http://localhost:8080/ > /dev/null

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     build: .
     ports:
       - "8080:8080"
+    restart: unless-stopped
     read_only: true
     security_opt:
       - no-new-privileges:true
@@ -15,9 +16,14 @@ services:
         limits:
           memory: 128m
           cpus: "0.5"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/"]
+      test: ["CMD", "curl", "-fs", "http://localhost:8080/"]
       interval: 10s
       timeout: 5s
-      retries: 10
-      start_period: 30s
+      retries: 3
+      start_period: 15s

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,39 +1,71 @@
-worker_processes auto;
-pid /tmp/nginx.pid;
+# OWASP-hardened nginx configuration for a static Angular SPA.
+# Threat model: public internet, TLS terminated upstream (CDN / load balancer).
+
+worker_processes     auto;
+worker_rlimit_nofile 8192;
+pid                  /tmp/nginx.pid;
 
 events {
     worker_connections 1024;
+    multi_accept       on;
 }
 
 http {
     include      /etc/nginx/mime.types;
     default_type application/octet-stream;
 
-    # OWASP: hide version info
+    # OWASP A05 — hide version from Server header and error pages
     server_tokens off;
 
-    sendfile          on;
-    tcp_nopush        on;
-    keepalive_timeout 65;
+    # OWASP A03 — reject ambiguous / injected request headers
+    underscores_in_headers off;
+    ignore_invalid_headers  on;
 
-    # Temp paths writable by the unprivileged nginx user
+    sendfile    on;
+    tcp_nopush  on;
+    tcp_nodelay on;
+
+    keepalive_timeout  65s;
+    keepalive_requests 1000;
+
+    # OWASP A05 — Slowloris / slow-read attack mitigation
+    client_body_timeout   10s;
+    client_header_timeout 10s;
+    send_timeout          10s;
+
+    # OWASP A05 — request-size guards (DoS, buffer-overflow)
+    client_max_body_size        1m;
+    client_header_buffer_size   1k;
+    large_client_header_buffers 4 8k;
+
+    # Temp paths writable by the unprivileged nginx user (/tmp is tmpfs)
     client_body_temp_path /tmp/client_body;
     proxy_temp_path       /tmp/proxy;
     fastcgi_temp_path     /tmp/fastcgi;
     uwsgi_temp_path       /tmp/uwsgi;
     scgi_temp_path        /tmp/scgi;
 
-    # Compression
+    # Compression — gzip_min_length avoids compressing tiny responses
+    # which mitigates BREACH/CRIME side-channel on very small payloads
     gzip            on;
     gzip_vary       on;
     gzip_comp_level 6;
+    gzip_min_length 256;
+    gzip_proxied    any;
     gzip_types      text/plain text/css application/json application/javascript
                     text/xml application/xml text/javascript image/svg+xml;
 
-    # Rate limiting — 30 req/s per IP, burst of 60
-    limit_req_zone $binary_remote_addr zone=main:10m rate=30r/s;
+    # OWASP A05 — per-IP rate and connection limits
+    limit_req_zone  $binary_remote_addr zone=req:10m  rate=30r/s;
+    limit_conn_zone $binary_remote_addr zone=conn:10m;
 
-    # Cache-Control: long-term immutable for hashed assets, no-store for HTML
+    # OWASP A09 — structured access log for security monitoring / SIEM ingestion
+    log_format main '$remote_addr [$time_local] "$request" $status $body_bytes_sent '
+                    '"$http_referer" "$http_user_agent"';
+    access_log /var/log/nginx/access.log main;
+    error_log  /var/log/nginx/error.log warn;
+
+    # Cache-Control: no-store for HTML, long-term immutable for hashed assets
     map $uri $cache_control_val {
         ~*\.html$   "no-cache, no-store, must-revalidate";
         default     "public, max-age=31536000, immutable";
@@ -44,31 +76,50 @@ http {
         default     max;
     }
 
+    # OWASP A03 — Content Security Policy defined as a map variable so the
+    # value stays readable without invalid backslash line-continuation.
+    # img-src whitelists every external CDN used by the tech-badge component
+    # and the CC licence icons in the footer; no wildcard https: to limit
+    # the exfiltration surface.
+    map $host $csp_header {
+        default "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://cdn.simpleicons.org https://mirrors.creativecommons.org https://upload.wikimedia.org https://cdn.phaser.io https://image.pngaaa.com https://logowik.com https://webhostinggeeks.com https://avatars.githubusercontent.com https://duckduckgo.com https://external-content.duckduckgo.com https://www.pngmart.com https://images.seeklogo.com https://www.clipartmax.com; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';";
+    }
+
     server {
-        listen 8080;
+        listen 8080 default_server;
         root  /usr/share/nginx/html/browser;
         index index.html;
         autoindex off;
 
-        limit_req zone=main burst=60 nodelay;
+        limit_conn conn 100;
+        limit_req  zone=req burst=60 nodelay;
 
-        expires    $expires_val;
+        expires $expires_val;
 
-        # Security headers (OWASP A05 / CWE-693)
-        add_header Cache-Control           $cache_control_val                                                                                                                                                   always;
-        add_header X-Frame-Options         "SAMEORIGIN"                                                                                                                                                         always;
-        add_header X-Content-Type-Options  "nosniff"                                                                                                                                                            always;
-        add_header X-XSS-Protection        "1; mode=block"                                                                                                                                                      always;
-        add_header Referrer-Policy         "strict-origin-when-cross-origin"                                                                                                                                    always;
-        add_header Permissions-Policy      "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()"                                                      always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://cdn.simpleicons.org https://mirrors.creativecommons.org https://upload.wikimedia.org https://cdn.phaser.io https://image.pngaaa.com https://logowik.com https://webhostinggeeks.com https://avatars.githubusercontent.com https://duckduckgo.com https://external-content.duckduckgo.com https://www.pngmart.com https://images.seeklogo.com https://www.clipartmax.com; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" always;
+        # ── Security response headers ─────────────────────────────────────
+        # OWASP A02 — HSTS (TLS terminated upstream; CDN forwards this header
+        #   to the client over HTTPS). Browsers except localhost from HSTS so
+        #   local Docker HTTP testing is unaffected.
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
 
-        # Restrict to safe HTTP methods only
+        # OWASP A05 / CWE-693
+        add_header Cache-Control          $cache_control_val                                                                 always;
+        add_header X-Frame-Options        "SAMEORIGIN"                                                                       always;
+        add_header X-Content-Type-Options "nosniff"                                                                          always;
+        add_header X-XSS-Protection       "1; mode=block"                                                                    always;
+        add_header Referrer-Policy        "strict-origin-when-cross-origin"                                                  always;
+        add_header Permissions-Policy     "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()" always;
+
+        # OWASP A03
+        add_header Content-Security-Policy $csp_header always;
+        # ─────────────────────────────────────────────────────────────────
+
+        # OWASP A05 — reject non-safe HTTP verbs
         if ($request_method !~ ^(GET|HEAD|POST)$) {
             return 405;
         }
 
-        # SPA fallback — serves index.html for any unknown path
+        # SPA fallback — Angular router handles client-side navigation
         location / {
             try_files $uri $uri/ /index.html;
         }


### PR DESCRIPTION
## Summary
Full OWASP production hardening pass across `nginx.conf`, `Dockerfile`, and `docker-compose.yml`.

## nginx.conf changes

| Area | Change | OWASP ref |
|---|---|---|
| File descriptors | `worker_rlimit_nofile 8192` | A05 |
| Header injection | `underscores_in_headers off`, `ignore_invalid_headers on` | A03 |
| Slowloris mitigation | `client_body/header/send_timeout 10s` | A05 |
| Request-size guards | `client_max_body_size 1m`, `client_header_buffer_size 1k`, `large_client_header_buffers 4 8k` | A05 |
| Connection limiting | `limit_conn_zone` + `limit_conn conn 100` per IP | A05 |
| BREACH/CRIME | `gzip_min_length 256` avoids compressing tiny payloads | A02 |
| HSTS | `max-age=63072000; includeSubDomains; preload` — safe because TLS is terminated upstream | A02 |
| CSP | Moved to `map $host $csp_header` — readable, no invalid backslash continuation | A03 |
| Logging | Structured `log_format main` for SIEM ingestion | A09 |

## Dockerfile changes
- Collapse `apk upgrade` + `rm` into one `RUN` layer
- `COPY --chown=nginx:nginx` — combines copy + ownership change (one fewer layer)
- `HEALTHCHECK` directive for standalone `docker run` / Kubernetes compatibility

## docker-compose.yml changes
- `restart: unless-stopped` — automatic recovery on OOM kill or crash
- `logging` with `max-size: 10m` / `max-file: 3` — prevents log-driven disk exhaustion
- Tightened healthcheck: `retries: 3` (was 10), `start_period: 15s` (was 30s)

## Test plan
- [x] `docker compose up --build` succeeds
- [ ] `http://localhost:8080/` loads with correct styles and theme
- [x] `curl -v http://localhost:8080/` response headers include `Strict-Transport-Security`, `Content-Security-Policy`, `X-Frame-Options`
- [x] `curl -X DELETE http://localhost:8080/` returns 405
- [x] Rapid requests from one IP hit rate/connection limits (429 or connection drop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)