### PR TITLE
fix: upgrade GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "24.x"
           cache: "npm"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
       # --- workflow_run path: reuse the artifact built and verified by integration tests ---
       - name: Download pre-built site from integration tests
         if: github.event_name != 'workflow_dispatch'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: site-build
           run-id: ${{ github.event.workflow_run.id }}
@@ -50,7 +50,7 @@ jobs:
 
       - name: Setup Node.js
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "24.x"
           cache: "npm"
@@ -65,7 +65,7 @@ jobs:
 
       # --- common: hand off to deploy job ---
       - name: Upload site for deployment
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: site-for-deploy
           path: site
@@ -78,7 +78,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Download site
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: site-for-deploy
           path: ${{ runner.temp }}/site-for-deploy

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "24.x"
           cache: "npm"
@@ -31,7 +31,7 @@ jobs:
         run: npm run build
 
       - name: Upload site build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: site-build
           path: public/usidiamond.github.io/browser
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "24.x"
           cache: "npm"
@@ -56,7 +56,7 @@ jobs:
         run: npm install
 
       - name: Download site build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: site-build
           path: public/usidiamond.github.io/browser
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload test report
         id: upload-report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: integration-test-report


### PR DESCRIPTION
## Summary
- `actions/setup-node@v4` → `@v5`
- `actions/upload-artifact@v4` → `@v7`
- `actions/download-artifact@v4` → `@v8`

Fixes the deprecation warning across all three workflows (`deploy.yml`, `integration-tests.yml`, `coverage.yml`):
> Node.js 20 actions are deprecated … Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

## Test plan
- [x] Integration Tests workflow passes on this PR
- [x] No Node.js 20 deprecation warnings in the Actions log

🤖 Generated with [Claude Code](https://claude.com/claude-code)